### PR TITLE
Prevent echoing Discord messages

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -26,5 +26,10 @@ module.exports = {
   startTime: 0,
   logger: null,
   lastMessages: null,
+  /**
+   * Stores WhatsApp message IDs that originate from Discord so that
+   * they are not echoed back to Discord when received from WhatsApp.
+   */
+  sentMessages: new Set(),
   goccRuns: {},
 };

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -56,6 +56,11 @@ const connectToWhatsApp = async (retry = 1) => {
     client.ev.on('messages.upsert', async (update) => {
         if (['notify', 'append'].includes(update.type)) {
             for await (const rawMessage of update.messages) {
+                const messageId = utils.whatsapp.getId(rawMessage);
+                if (state.sentMessages.has(messageId)) {
+                    state.sentMessages.delete(messageId);
+                    continue;
+                }
                 const messageType = utils.whatsapp.getMessageType(rawMessage);
                 if (!utils.whatsapp.inWhitelist(rawMessage) || !utils.whatsapp.sentAfterStart(rawMessage) || !messageType) continue;
 
@@ -157,7 +162,10 @@ const connectToWhatsApp = async (retry = 1) => {
         if (state.settings.UploadAttachments) {
             await Promise.all(message.attachments.map((file) =>
                 client.sendMessage(jid, utils.whatsapp.createDocumentContent(file))
-                    .then(m => { state.lastMessages[message.id] = m.key.id })
+                    .then(m => {
+                        state.lastMessages[message.id] = m.key.id;
+                        state.sentMessages.add(m.key.id);
+                    })
             ));
             content.text = message.content || "";
         } else {
@@ -177,7 +185,9 @@ const connectToWhatsApp = async (retry = 1) => {
 
         if (message.content === "") return;
 
-        state.lastMessages[message.id] = (await client.sendMessage(jid, content, options)).key.id;
+        const sent = await client.sendMessage(jid, content, options);
+        state.lastMessages[message.id] = sent.key.id;
+        state.sentMessages.add(sent.key.id);
     });
 
     client.ev.on('discordEdit', async ({ jid, message }) => {
@@ -195,13 +205,14 @@ const connectToWhatsApp = async (retry = 1) => {
             key.participant = utils.whatsapp.toJid(message.author.username);
         }
 
-        await client.sendMessage(
+        const editMsg = await client.sendMessage(
             jid,
             {
                 text: message.content,
                 edit: key,
             }
-        )
+        );
+        state.sentMessages.add(editMsg.key.id);
     });
 
     client.ev.on('discordReaction', async ({ jid, reaction, removed }) => {
@@ -219,15 +230,15 @@ const connectToWhatsApp = async (retry = 1) => {
             key.participant = utils.whatsapp.toJid(reaction.message.author.username);
         }
 
-        const messageId = (
-            await client.sendMessage(jid, {
-                react: {
-                    text: removed ? '' : reaction.emoji.name,
-                    key,
-                },
-            })
-        ).key.id;
+        const reactionMsg = await client.sendMessage(jid, {
+            react: {
+                text: removed ? '' : reaction.emoji.name,
+                key,
+            },
+        });
+        const messageId = reactionMsg.key.id;
         state.lastMessages[messageId] = true;
+        state.sentMessages.add(messageId);
     });
 
     return client;


### PR DESCRIPTION
## Summary
- track WhatsApp message ids that originate from Discord
- ignore those ids when mirroring WhatsApp updates back to Discord