### PR TITLE
Handle invalid WhatsApp sessions

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -26,5 +26,10 @@ module.exports = {
   startTime: 0,
   logger: null,
   lastMessages: null,
+  /**
+   * Stores WhatsApp message IDs that originate from Discord so that
+   * they are not echoed back to Discord when received from WhatsApp.
+   */
+  sentMessages: new Set(),
   goccRuns: {},
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,13 +127,21 @@ const updater = {
   },
 
   async run(currVer) {
-    if (process.argv.some(arg => ['--skip-update', '-su'].includes(arg))) {
-      console.log('Skipping update due to command line argument.');
+    if (
+      process.argv.some((arg) => ['--skip-update', '-su'].includes(arg)) ||
+      process.env.WA2DC_SKIP_UPDATE === '1'
+    ) {
+      console.log('Skipping update due to configuration.');
       return;
     }
 
     if (this.isNode) {
       console.log('Running script with node. Skipping auto-update.');
+      return;
+    }
+
+    if (!process.stdin.isTTY) {
+      console.log('Skipping auto-update due to non-interactive environment.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- track Discord-sent message IDs to avoid echoing back from WhatsApp
- restart WhatsApp connection if session becomes invalid
- skip update prompt in non-interactive environments