### PR TITLE
Fix auto bump to open PR

### DIFF
--- a/.github/workflows/new-release-v2.yml
+++ b/.github/workflows/new-release-v2.yml
@@ -21,13 +21,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Auto bump version
-        if: github.ref_type == 'branch' && !contains(github.event.head_commit.message, 'chore: release')
+        if: "github.ref_type == 'branch' && !contains(github.event.head_commit.message, 'chore: release')"
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           NEW_TAG=$(npm version patch -m "chore: release %s")
-          git push origin HEAD --tags
-          echo "::notice ::Created $NEW_TAG"
+          BRANCH="release-${NEW_TAG}"
+          git switch -c "$BRANCH"
+          git push -u origin "$BRANCH" --tags
+          gh pr create --title "chore: release $NEW_TAG" --body "Automated release PR for $NEW_TAG"
+          echo "::notice ::Created PR for $NEW_TAG"
           exit 0
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- create a PR in the release workflow instead of pushing to main