### PR TITLE
Add Discord update prompt post-startup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -144,3 +144,11 @@ Allows sending webhook messages to be redirected to WhatsApp.
 ## ping
 Replies back with *"Pong <Now - Time Message Sent>"ms*. It basically shows the bot's ping with the server. An unsynced date and time on your computer may cause big or even negative ping results, however, it doesn't mean you got negative ping or 10mins of lag, rather it is the Discord's time and your computer's time difference plus your ping.
 - Format: `ping`
+
+## update
+Downloads and installs the latest version when the bot notifies you that a new release is available. The notification message also includes a link to the GitHub release so you can review the changes.
+- Format: `update`
+
+## skipUpdate
+Clears the current update notification without installing anything.
+- Format: `skipUpdate`

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -347,6 +347,24 @@ const commands = {
     state.settings.redirectWebhooks = params[0] === "yes";
     await controlChannel.send(`Redirecting webhooks is set to ${state.settings.redirectWebhooks}.`);
   },
+  async update() {
+    if (!state.updateInfo) {
+      await controlChannel.send('No update available.');
+      return;
+    }
+    await controlChannel.send('Updating...');
+    const success = await utils.updater.update();
+    if (success) {
+      await controlChannel.send('Update downloaded. Restarting...');
+      process.exit();
+    } else {
+      await controlChannel.send('Update failed. Check logs.');
+    }
+  },
+  async skipupdate() {
+    state.updateInfo = null;
+    await controlChannel.send('Update skipped.');
+  },
   async unknownCommand(message) {
     await controlChannel.send(`Unknown command: \`${message.content}\`\nType \`help\` to see available commands`);
   },

--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,6 @@ const whatsappHandler =  require('./whatsappHandler.js');
 
   state.logger.info('Starting');
 
-  await utils.updater.run(version);
-  state.logger.info('Update checked.');
-
   const conversion = await utils.sqliteToJson.convert();
   if (!conversion) {
     state.logger.error('Conversion failed!');
@@ -72,6 +69,18 @@ const whatsappHandler =  require('./whatsappHandler.js');
 
   await whatsappHandler.start();
   state.logger.info('WhatsApp client started.');
+
+  await utils.updater.run(version, { prompt: false });
+  state.logger.info('Update checked.');
+
+  if (state.updateInfo) {
+    const ctrl = await utils.discord.getControlChannel();
+    await ctrl?.send(
+      `A new version is available ${state.updateInfo.currVer} -> ${state.updateInfo.version}.\n` +
+      `See ${state.updateInfo.url}\n` +
+      `Changelog: ${state.updateInfo.changes}\nType \`update\` to apply or \`skipUpdate\` to ignore.`
+    );
+  }
 
   state.logger.info('Bot is now running. Press CTRL-C to exit.');
 })();

--- a/src/state.js
+++ b/src/state.js
@@ -32,4 +32,5 @@ module.exports = {
    */
   sentMessages: new Set(),
   goccRuns: {},
+  updateInfo: null,
 };


### PR DESCRIPTION
## Summary
- run WhatsApp before checking for updates
- allow running the updater without prompting
- include release URL when notifying about updates
- document `update` and `skipUpdate` commands