### PR TITLE
Fix quoting media download and improve restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-  const version = 'v1.1.8';
+  const version = 'v1.1.9';
   const streams = [
     { stream: pino.destination('logs.txt') },
     { stream: pretty({ colorize: true }) },

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const { fork } = require('child_process');
 const path = require('path');
 const pino = require('pino');
 const pretty = require('pino-pretty');
@@ -15,7 +15,7 @@ let child;
 let shuttingDown = false;
 
 function start() {
-  child = spawn(process.argv0, ['--no-deprecation', INDEX_PATH], { stdio: 'inherit' });
+  child = fork(INDEX_PATH, [], { stdio: 'inherit', execArgv: ['--no-deprecation'] });
 
   child.on('exit', (code, signal) => {
     if (shuttingDown) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -501,7 +501,10 @@ const whatsapp = {
   isQuoted(msg) {
     return msg.contextInfo?.quotedMessage;
   },
-  async getQuote(msg) {
+  async getQuote(rawMsg) {
+    const msgType = this.getMessageType(rawMsg);
+    const [, msg] = this.getMessage(rawMsg, msgType);
+
     if (!this.isQuoted(msg)) return null;
 
     const qMsg = msg.contextInfo.quotedMessage;
@@ -509,7 +512,16 @@ const whatsapp = {
 
     const [nMsgType, message] = this.getMessage({ message: qMsg }, qMsgType);
     const content = this.getContent(message, nMsgType, qMsgType);
-    const file = await this.getFile({ message: qMsg }, qMsgType);
+    const downloadCtx = {
+      key: {
+        remoteJid: rawMsg.key.remoteJid,
+        id: msg.contextInfo.stanzaId,
+        fromMe: rawMsg.key.fromMe,
+        participant: msg.contextInfo.participant,
+      },
+      message: qMsg,
+    };
+    const file = await this.getFile(downloadCtx, qMsgType);
 
     return {
       name: this.jidToName(msg.contextInfo.participant || ''),

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -87,7 +87,7 @@ const connectToWhatsApp = async (retry = 1) => {
                     id: utils.whatsapp.getId(rawMessage),
                     name: utils.whatsapp.getSenderName(rawMessage),
                     content: utils.whatsapp.getContent(message, nMsgType, messageType),
-                    quote: await utils.whatsapp.getQuote(message),
+                    quote: await utils.whatsapp.getQuote(rawMessage),
                     file: await utils.whatsapp.getFile(rawMessage, messageType),
                     profilePic: await utils.whatsapp.getProfilePic(rawMessage),
                     channelJid: utils.whatsapp.getChannelJid(rawMessage),


### PR DESCRIPTION
## Summary
- improve detection of quoted messages
- pass correct context when downloading quoted media
- use `fork` in runner for self-restarts
- bump version to 1.1.9