### PR TITLE
Fix crash when quoting expired media

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now
 - Self Hosted, so your data never leaves your computer
 - Automatically restarts itself if it crashes
 
+### Running
+
+Run the bot with `npm start` or use the executable downloaded from the releases
+page. Both methods use a small helper script that watches the process and
+restarts it automatically if it exits unexpectedly. Directly running
+`node src/index.js` will skip this helper and the bot won't restart on crashes.
+
 ---
 
 ### For setup and commands, check out the [documentation](https://arespawn.github.io/WhatsAppToDiscord/)!

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,13 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), now maintained by 
 - Self Hosted, so your data never leaves your computer
 - Automatically restarts itself if it crashes
 
+### Running
+
+Start the bot with `npm start` or run the executable from the releases page. The
+start script keeps an eye on the process and brings it back up if it crashes.
+Launching `node src/index.js` directly skips this behaviour, so crashes will
+stop the bot.
+
 ### Setup
 
 The setup is short, but challenging for some. So, we explained every steps in detail for your convenience, just [click here](setup.md) to get started.

--- a/src/utils.js
+++ b/src/utils.js
@@ -556,11 +556,16 @@ const whatsapp = {
     const [nMsgType, msg] = this.getMessage(rawMsg, msgType);
     if (msg.fileLength == null) return;
     if (msg.fileLength.low > 26214400 && !state.settings.LocalDownloads) return -1;
-    return {
-      name: this.getFilename(msg, nMsgType),
-      attachment: await downloadMediaMessage(rawMsg, 'buffer', {}, { logger: state.logger, reuploadRequest: state.waClient.updateMediaMessage }),
-      largeFile: msg.fileLength.low > 26214400,
-    };
+    try {
+      return {
+        name: this.getFilename(msg, nMsgType),
+        attachment: await downloadMediaMessage(rawMsg, 'buffer', {}, { logger: state.logger, reuploadRequest: state.waClient.updateMediaMessage }),
+        largeFile: msg.fileLength.low > 26214400,
+      };
+    } catch (err) {
+      state.logger?.error(err);
+      return null;
+    }
   },
   inWhitelist(rawMsg) {
     return state.settings.Whitelist.length === 0 || state.settings.Whitelist.includes(rawMsg?.key?.remoteJid || rawMsg.chatId);


### PR DESCRIPTION
## Summary
- handle failures when downloading WhatsApp media so the bot doesn't crash
- document how to run the bot so the restart helper works