### PR TITLE
Fix null handling and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -40,11 +40,11 @@ client.on('whatsappMessage', async (message) => {
   if (message.isGroup && state.settings.WAGroupPrefix) { msgContent += `[${message.name}] `; }
 
   if (message.isForwarded) {
-    msgContent += `forwarded message:\n${message.content.split('\n').join('\n> ')}`;
+    msgContent += `forwarded message:\n${(message.content || '').split('\n').join('\n> ')}`;
   }
   else if (message.quote) {
     const qContent = (message.quote.content || '').split('\n').join('\n> ');
-    msgContent += `> ${message.quote.name}: ${qContent}\n${message.content}`;
+    msgContent += `> ${message.quote.name}: ${qContent}\n${message.content || ''}`;
     if (message.quote.file) {
       if (message.quote.file.largeFile && state.settings.LocalDownloads) {
         msgContent += await utils.discord.downloadLargeFile(message.quote.file);

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-  const version = 'v1.1.9';
+  const version = 'v1.1.10';
   const streams = [
     { stream: pino.destination('logs.txt') },
     { stream: pretty({ colorize: true }) },

--- a/src/utils.js
+++ b/src/utils.js
@@ -550,7 +550,8 @@ const whatsapp = {
     else if ('documentMessage' === msgType) {
       return msg.fileName;
     }
-    return `${msgType}.${msg.mimetype.split('/')[1]}`;
+    const ext = msg.mimetype?.split('/')?.[1] || 'bin';
+    return `${msgType}.${ext}`;
   },
   async getFile(rawMsg, msgType) {
     const [nMsgType, msg] = this.getMessage(rawMsg, msgType);
@@ -627,11 +628,11 @@ const whatsapp = {
     }
   },
   createDocumentContent(attachment) {
-    let contentType = attachment.contentType.split('/')[0];
+    let contentType = attachment.contentType?.split('/')?.[0] || 'application';
     contentType = ['image', 'video', 'audio'].includes(contentType) ? contentType : 'document';
     const documentContent = {};
     if (contentType === 'document') {
-      documentContent['mimetype'] = attachment.contentType.split(';')[0];
+      documentContent['mimetype'] = attachment.contentType?.split(';')?.[0] || 'application/octet-stream';
     }
     documentContent[contentType] = { url: attachment.url };
     if (contentType === 'document') {


### PR DESCRIPTION
## Summary
- prevent crash when forwarded or quoted messages have no content
- handle missing mimetype when generating filenames
- allow attachments without content type
- bump version to 1.1.10