### PR TITLE
Fix dropping WhatsApp messages sent simultaneously

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -578,7 +578,9 @@ const whatsapp = {
     return 0;
   },
   sentAfterStart(rawMsg) {
-    return this.getTimestamp(rawMsg) > state.startTime;
+    const ts = this.getTimestamp(rawMsg);
+    const id = rawMsg?.key?.id;
+    return ts > state.startTime || !Object.prototype.hasOwnProperty.call(state.lastMessages, id);
   },
   getMessageType(rawMsg) {
     return ['conversation', 'extendedTextMessage', 'imageMessage', 'videoMessage', 'audioMessage', 'documentMessage', 'documentWithCaptionMessage', 'viewOnceMessageV2', 'stickerMessage', 'editedMessage'].find((el) => Object.hasOwn(rawMsg.message || {}, el));


### PR DESCRIPTION
## Summary
- Updated the timestamp filtering to also check if a message ID was already processed, ensuring that multiple attachments sent at the same time are all forwarded