### PR TITLE
Improve crash notifications and update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now
 - Open Source, you can see, modify and run your own version of the bot!
 - Self Hosted, so your data never leaves your computer
 - Automatically restarts itself if it crashes
+- Restarts automatically after applying updates and checks for new versions every couple of days
 
 ### Running
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -149,6 +149,10 @@ Replies back with *"Pong <Now - Time Message Sent>"ms*. It basically shows the b
 Downloads and installs the latest version when the bot notifies you that a new release is available. The notification message also includes a link to the GitHub release so you can review the changes.
 - Format: `update`
 
+## checkUpdate
+Manually checks if a new version is available and posts the result in the control channel.
+- Format: `checkUpdate`
+
 ## skipUpdate
 Clears the current update notification without installing anything.
 - Format: `skipUpdate`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -2,6 +2,7 @@ const { Client, Intents } = require('discord.js');
 
 const state = require('./state.js');
 const utils = require('./utils.js');
+const fs = require('fs');
 
 const client = new Client({
   intents: [
@@ -366,9 +367,22 @@ const commands = {
     const success = await utils.updater.update();
     if (success) {
       await controlChannel.send('Update downloaded. Restarting...');
+      await fs.promises.writeFile('restart.flag', '');
       process.exit();
     } else {
       await controlChannel.send('Update failed. Check logs.');
+    }
+  },
+  async checkupdate() {
+    await utils.updater.run(state.version, { prompt: false });
+    if (state.updateInfo) {
+      await controlChannel.send(
+        `A new version is available ${state.updateInfo.currVer} -> ${state.updateInfo.version}.\n` +
+        `See ${state.updateInfo.url}\n` +
+        `Changelog: ${state.updateInfo.changes}\nType \`update\` to apply or \`skipUpdate\` to ignore.`
+      );
+    } else {
+      await controlChannel.send('No update available.');
     }
   },
   async skipupdate() {

--- a/src/state.js
+++ b/src/state.js
@@ -33,4 +33,5 @@ module.exports = {
   sentMessages: new Set(),
   goccRuns: {},
   updateInfo: null,
+  version: '',
 };


### PR DESCRIPTION
## Summary
- restart after updates by using a flag file watched by `runner.js`
- send crash information and recent logs to Discord before exiting
- add periodic update checks and `checkUpdate` command
- document the new command and auto-update behavior
- bump version to 1.1.11