### PR TITLE
Add optional rename in resync and control room protection

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,8 +38,8 @@ Removes the given channel from the whitelist.
     - `removeFromWhitelist #john-doe`: This would remove John Doe from the whitelist, preventing them to send you a message if you have whitelist enabled.
 
 ## resync
-Re-syncs your contacts and groups, and renames channels. Can be used when the bot can't find your desired contact or group.
-- Format: `resync`
+Re-syncs your contacts and groups. Can optionally rename the Discord channels to match WhatsApp names.
+- Format: `resync [rename]`
 
 ## enableWAUpload
 When enabled (enabled by default), the files received from Discord will be uploaded to WhatsApp, instead of providing a link to the attachment. File uploads takes longer and consumes more data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-  const version = 'v1.1.11';
+  const version = 'v1.1.12';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/src/utils.js
+++ b/src/utils.js
@@ -422,14 +422,27 @@ const discord = {
     const guild = await this.getGuild();
 
     for (const [jid, webhook] of Object.entries(state.chats)) {
-      const channel = await guild.channels.fetch(webhook.channelId);
-      await channel.edit({
-        name: whatsapp.jidToName(jid),
-      });
+      try {
+        const channel = await guild.channels.fetch(webhook.channelId);
+        await channel.edit({
+          name: whatsapp.jidToName(jid),
+        });
+      } catch (err) {
+        state.logger?.error(err);
+      }
     }
   },
   async getControlChannel() {
-    return this.getChannel(state.settings.ControlChannelID);
+    let channel = await this.getChannel(state.settings.ControlChannelID);
+    if (!channel) {
+      channel = await this.createChannel('control-room');
+      state.settings.ControlChannelID = channel.id;
+      await channel.edit({
+        position: 0,
+        parent: await this.getCategory(0),
+      });
+    }
+    return channel;
   },
   async findAvailableName(dir, fileName) {
     let absPath;


### PR DESCRIPTION
## Summary
- bump version to 1.1.12
- allow `resync` to rename channels only when `rename` parameter is supplied
- safeguard control room recreation if deleted
- handle rename errors without crashing
- update docs for the new resync usage