### PR TITLE
Add bold Discord prefix on WhatsApp messages

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,15 +50,15 @@ When disabled (enabled by default), the files received from Discord will be sent
 - Format: `disableWAUpload`
 
 ## setDCPrefix
-When set (your username by default), the prefix will be added to messages sent to WhatsApp from Discord.
+When set (your username by default), the prefix will be added in bold followed by a newline to messages sent to WhatsApp from Discord.
 - Format: `setDCPrefix`
 
 ## enableDCPrefix
-When enabled (disabled by default), your Discord username will be added to messages sent to WhatsApp from Discord.
+When enabled (disabled by default), your Discord username will be added in bold followed by a newline to messages sent to WhatsApp from Discord.
 - Format: `enableDCPrefix`
 
 ## disableDCPrefix
-When disabled (disabled by default), your Discord username won't be added to messages sent to WhatsApp from Discord.
+When disabled (disabled by default), your Discord username won't be added in bold followed by a newline to messages sent to WhatsApp from Discord.
 - Format: `disableDCPrefix`
 
 ## enableWAPrefix

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -191,7 +191,8 @@ const connectToWhatsApp = async (retry = 1) => {
         }
 
         if (state.settings.DiscordPrefix) {
-            content.text = `[${state.settings.DiscordPrefixText || message.member?.nickname || message.author.username}] ${content.text}`;
+            const prefix = state.settings.DiscordPrefixText || message.member?.nickname || message.author.username;
+            content.text = `*${prefix}*\n${content.text}`;
         }
 
         if (message.reference) {
@@ -223,10 +224,16 @@ const connectToWhatsApp = async (retry = 1) => {
             key.participant = utils.whatsapp.toJid(message.author.username);
         }
 
+        let text = message.content;
+        if (state.settings.DiscordPrefix) {
+            const prefix = state.settings.DiscordPrefixText || message.member?.nickname || message.author.username;
+            text = `*${prefix}*\n${text}`;
+        }
+
         const editMsg = await client.sendMessage(
             jid,
             {
-                text: message.content,
+                text,
                 edit: key,
             }
         );


### PR DESCRIPTION
## Summary
- format Discord username prefix in bold with a newline when forwarding messages to WhatsApp
- document the updated prefix behaviour

Thanks to [PoBruno](https://github.com/PoBruno) [#203](https://github.com/FKLC/WhatsAppToDiscord/pull/203)