### PR TITLE
support cross-platform mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now
 - Supports media (Image, Video, Audio, Document, Stickers) and reactions!
 - Allows whitelisting, so you can choose what to see on Discord
 - Allows usage of WhatsApp through the Discord overlay
+- Translates mentions between WhatsApp and Discord
 - It uses less memory as it doesn't simulate a browser
 - Open Source, you can see, modify and run your own version of the bot!
 - Self Hosted, so your data never leaves your computer

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now
 - Supports media (Image, Video, Audio, Document, Stickers) and reactions!
 - Allows whitelisting, so you can choose what to see on Discord
 - Allows usage of WhatsApp through the Discord overlay
-- Translates mentions between WhatsApp and Discord
 - It uses less memory as it doesn't simulate a browser
 - Open Source, you can see, modify and run your own version of the bot!
 - Self Hosted, so your data never leaves your computer

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), now maintained by 
 - Supports media (Image, Video, Audio, Document, Stickers) and reactions!
 - Allows whitelisting, so you can choose what to see on Discord
 - Allows usage of WhatsApp through the Discord overlay
+- Translates mentions between WhatsApp and Discord
 - It uses less memory as it doesn't simulate a browser
 - Open Source, you can see, modify and run your own version of the bot!
 - Self Hosted, so your data never leaves your computer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-  const version = 'v1.1.12';
+  const version = 'v1.1.13';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },
@@ -33,7 +33,9 @@ const whatsappHandler =  require('./whatsappHandler.js');
           try {
             logs = await fs.promises.readFile('logs.txt', 'utf8');
             logs = logs.split('\n').slice(-20).join('\n');
-          } catch {}
+          } catch (err) {
+            // ignore read errors
+          }
           await ctrl.send(
             `Bot crashed: \n\n\u0060\u0060\u0060\n${err?.stack || err}\n\u0060\u0060\u0060` +
             (logs ? `\nRecent logs:\n\u0060\u0060\u0060\n${logs}\n\u0060\u0060\u0060` : '')

--- a/src/utils.js
+++ b/src/utils.js
@@ -491,6 +491,17 @@ const whatsapp = {
   contacts() {
     return Object.values(state.waClient.contacts);
   },
+  getMentionedJids(text) {
+    const mentions = [];
+    if (!text) return mentions;
+    const lower = text.toLowerCase();
+    for (const [jid, name] of Object.entries(state.contacts)) {
+      if (lower.includes(`@${name.toLowerCase()}`)) {
+        mentions.push(jid);
+      }
+    }
+    return mentions;
+  },
   async sendQR(qrString) {
     await (await discord.getControlChannel())
       .send({ files: [new MessageAttachment(await QRCode.toBuffer(qrString), 'qrcode.png')] });
@@ -629,6 +640,12 @@ const whatsapp = {
       case 'stickerMessage':
         content += msg.caption || '';
         break;
+    }
+    const mentions = msg.contextInfo?.mentionedJid || [];
+    for (const jid of mentions) {
+      const name = this.jidToName(jid);
+      const regex = new RegExp(`@${this.jidToPhone(jid)}\\b`, 'g');
+      content = content.replace(regex, `@${name}`);
     }
     return content;
   },

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -202,6 +202,11 @@ const connectToWhatsApp = async (retry = 1) => {
             }
         }
 
+        const mentionJids = utils.whatsapp.getMentionedJids(content.text);
+        if (mentionJids.length) {
+            content.mentions = mentionJids;
+        }
+
         if (message.content === "") return;
 
         const sent = await client.sendMessage(jid, content, options);
@@ -229,12 +234,13 @@ const connectToWhatsApp = async (retry = 1) => {
             const prefix = state.settings.DiscordPrefixText || message.member?.nickname || message.author.username;
             text = `*${prefix}*\n${text}`;
         }
-
+        const editMentions = utils.whatsapp.getMentionedJids(text);
         const editMsg = await client.sendMessage(
             jid,
             {
                 text,
                 edit: key,
+                ...(editMentions.length ? { mentions: editMentions } : {}),
             }
         );
         state.sentMessages.add(editMsg.key.id);


### PR DESCRIPTION
The update (implements feature suggestion #32) improves how mentions (pings) from **WhatsApp** and **Discord** are handled when messages are sent between the two platforms:

### WhatsApp → Discord:

* When someone tags a number on WhatsApp (like `@+3069...`), the bot now **replaces the phone number** with the person's **saved contact name** (like `@John`), so you don't see a bunch of raw phone numbers in Discord chats.

### Discord → WhatsApp:

* If someone types `@John Doe` on Discord, the bot **figures out who that is** and matches it with the correct WhatsApp contact (using something called a JID — a unique WhatsApp ID).
* Then it sends the message to WhatsApp in a way that **actually pings** that person, just like if you mentioned them directly on WhatsApp.
