### PR TITLE
fix: avoid mass mentions when replying

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -494,8 +494,15 @@ const whatsapp = {
   getMentionedJids(text) {
     const mentions = [];
     if (!text) return mentions;
-    const lower = text.toLowerCase();
+
+    // Discord replies include mentions in the form <@123> or <@!123>.
+    // These numeric identifiers can partially match many WhatsApp contact
+    // numbers which results in everyone in the group being mentioned.
+    // Strip such Discord-specific mentions before scanning for @names.
+    const lower = text.replace(/<@!?\d+>/g, '').toLowerCase();
+
     for (const [jid, name] of Object.entries(state.contacts)) {
+      if (!name) continue;
       if (lower.includes(`@${name.toLowerCase()}`)) {
         mentions.push(jid);
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -494,11 +494,7 @@ const whatsapp = {
   getMentionedJids(text) {
     const mentions = [];
     if (!text) return mentions;
-
-    // Discord replies include mentions in the form <@123> or <@!123>.
-    // These numeric identifiers can partially match many WhatsApp contact
-    // numbers which results in everyone in the group being mentioned.
-    // Strip such Discord-specific mentions before scanning for @names.
+    
     const lower = text.replace(/<@!?\d+>/g, '').toLowerCase();
 
     for (const [jid, name] of Object.entries(state.contacts)) {


### PR DESCRIPTION
## Summary
- strip Discord <@123> tags before searching for WhatsApp mentions