### PR TITLE
Sync WhatsApp message edits to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now
 - Supports media (Image, Video, Audio, Document, Stickers) and reactions!
 - Allows whitelisting, so you can choose what to see on Discord
 - Allows usage of WhatsApp through the Discord overlay
+- Syncs message edits between WhatsApp and Discord
 - It uses less memory as it doesn't simulate a browser
 - Open Source, you can see, modify and run your own version of the bot!
 - Self Hosted, so your data never leaves your computer

--- a/src/utils.js
+++ b/src/utils.js
@@ -375,6 +375,25 @@ const discord = {
       throw err;
     }
   },
+  async safeWebhookEdit(webhook, messageId, args, jid) {
+    try {
+      return await webhook.editMessage(messageId, args);
+    } catch (err) {
+      if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
+        delete state.goccRuns[jid];
+        const channel = await this.getChannel(state.chats[jid].channelId);
+        webhook = await channel.createWebhook('WA2DC');
+        state.chats[jid] = {
+          id: webhook.id,
+          type: webhook.type,
+          token: webhook.token,
+          channelId: webhook.channelId,
+        };
+        return await webhook.editMessage(messageId, args);
+      }
+      throw err;
+    }
+  },
   async repairChannels() {
     const guild = await this.getGuild();
     await guild.channels.fetch();


### PR DESCRIPTION
## Summary
- add safe helper for editing webhook messages
- forward WhatsApp message edits by updating the original Discord message (fallback to the old method in case not possible)
- document that edits are synchronized between platforms