### PR TITLE
Improve Discord edit forwarding

### DIFF
--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -484,6 +484,11 @@ client.on('messageUpdate', async (_, message) => {
     return;
   }
 
+  if (message.content.trim() === '') {
+    await message.channel.send('Edited message has no text to send to WhatsApp.');
+    return;
+  }
+
   state.waClient.ev.emit('discordEdit', { jid, message });
 })
 

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -265,6 +265,7 @@ const connectToWhatsApp = async (retry = 1) => {
             state.sentMessages.add(editMsg.key.id);
         } catch (err) {
             state.logger?.error(err);
+            await message.channel.send("Couldn't edit the message on WhatsApp.");
         }
     });
 


### PR DESCRIPTION
## Summary
- ignore Discord message edits with no text and notify the user instead of forwarding
- alert the Discord channel when editing a message on WhatsApp fails