### PR TITLE
Add toggle for message delete sync and webhook support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,6 +69,14 @@ When enabled (disabled by default), WhatsApp names will be added to messages sen
 When disabled (disabled by default), WhatsApp names won't be added to messages sent to Discord from WhatsApp. (Note that the bot already sets the username to the message sender's name)
 - Format: `disableWAPrefix`
 
+## enableDeletes
+When enabled (enabled by default), deleting a message on one platform removes it from the other.
+- Format: `enableDeletes`
+
+## disableDeletes
+When disabled, deleting a message on one platform will not affect the other, keeping the history.
+- Format: `disableDeletes`
+
 ## enableLocalDownloads
 When enabled, the bot downloads files larger than 8MB to your download location. See `getDownloadDir` for your download location.
 - Format: `enableLocalDownloads`

--- a/src/state.js
+++ b/src/state.js
@@ -18,6 +18,7 @@ module.exports = {
     lastMessageStorage: 500,
     oneWay: 0b11,
     redirectWebhooks: false,
+    DeleteMessages: true,
   },
   dcClient: null,
   waClient: null,

--- a/src/utils.js
+++ b/src/utils.js
@@ -394,6 +394,25 @@ const discord = {
       throw err;
     }
   },
+  async safeWebhookDelete(webhook, messageId, jid) {
+    try {
+      return await webhook.deleteMessage(messageId);
+    } catch (err) {
+      if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
+        delete state.goccRuns[jid];
+        const channel = await this.getChannel(state.chats[jid].channelId);
+        webhook = await channel.createWebhook('WA2DC');
+        state.chats[jid] = {
+          id: webhook.id,
+          type: webhook.type,
+          token: webhook.token,
+          channelId: webhook.channelId,
+        };
+        return await webhook.deleteMessage(messageId);
+      }
+      throw err;
+    }
+  },
   async repairChannels() {
     const guild = await this.getGuild();
     await guild.channels.fetch();


### PR DESCRIPTION
## Summary
- allow messages sent via webhooks to be deleted across platforms
- add `enableDeletes`/`disableDeletes` commands to toggle delete syncing
- ensure WhatsApp deletions remove corresponding Discord messages
- document delete-sync option