### PR TITLE
Handle invalid PNG attachments gracefully

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-  const version = 'v1.1.14';
+  const version = 'v1.1.15';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/src/utils.js
+++ b/src/utils.js
@@ -629,7 +629,13 @@ const whatsapp = {
         largeFile: msg.fileLength.low > 26214400,
       };
     } catch (err) {
-      state.logger?.error(err);
+      if (err?.message?.includes('Unrecognised filter type')) {
+        // Jimp sometimes throws this error when a PNG file is corrupted or malformed.
+        // Avoid spamming the log with a stack trace for such cases.
+        state.logger?.warn('Skipped sending attachment due to an invalid PNG file');
+      } else {
+        state.logger?.error(err);
+      }
       return null;
     }
   },


### PR DESCRIPTION
## Summary
- avoid logging stack traces when Jimp fails to parse a PNG
- bump version to 1.1.15