### PR TITLE
Handle WhatsApp message deletions via update events

### DIFF
--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -156,10 +156,20 @@ client.on('whatsappDelete', async ({ id, jid }) => {
     return;
   }
 
+  const webhook = await utils.discord.getOrCreateChannel(jid);
   try {
-    const webhook = await utils.discord.getOrCreateChannel(jid);
     await utils.discord.safeWebhookDelete(webhook, messageId, jid);
   } catch (err) {
+    try {
+      await utils.discord.safeWebhookEdit(
+        webhook,
+        messageId,
+        { content: '[deleted message]' },
+        jid,
+      );
+    } catch (err2) {
+      state.logger?.error(err2);
+    }
     state.logger?.error(err);
   }
 });


### PR DESCRIPTION
## Summary
- propagate WhatsApp deletions by listening for `messages.update` REVOKE events
- fall back to replacing Discord messages with a deleted notice if deletion fails