### PR TITLE
Edit Discord message when WhatsApp message deleted

### DIFF
--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -193,18 +193,13 @@ client.on('whatsappDelete', async ({ id, jid }) => {
 
   const webhook = await utils.discord.getOrCreateChannel(jid);
   try {
-    await utils.discord.safeWebhookDelete(webhook, messageId, jid);
+    await utils.discord.safeWebhookEdit(
+      webhook,
+      messageId,
+      { content: 'Message Delete' },
+      jid,
+    );
   } catch (err) {
-    try {
-      await utils.discord.safeWebhookEdit(
-        webhook,
-        messageId,
-        { content: '[deleted message]' },
-        jid,
-      );
-    } catch (err2) {
-      state.logger?.error(err2);
-    }
     state.logger?.error(err);
   }
 });

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -196,7 +196,7 @@ client.on('whatsappDelete', async ({ id, jid }) => {
     await utils.discord.safeWebhookEdit(
       webhook,
       messageId,
-      { content: 'Message Delete' },
+      { content: 'Message Deleted' },
       jid,
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
- edit Discord messages to say "Message Delete" when WhatsApp deletion occurs, instead of attempting to delete the message