### PR TITLE
Normalize JID for WhatsApp delete events

### DIFF
--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -122,7 +122,7 @@ const connectToWhatsApp = async (retry = 1) => {
                 if (!utils.whatsapp.inWhitelist({ chatId: key.remoteJid })) continue;
                 state.dcClient.emit('whatsappDelete', {
                     id: key.id,
-                    jid: key.remoteJid,
+                    jid: utils.whatsapp.formatJid(key.remoteJid),
                 });
             }
         }
@@ -136,7 +136,7 @@ const connectToWhatsApp = async (retry = 1) => {
             if (!utils.whatsapp.inWhitelist({ chatId: msgKey.remoteJid })) continue;
             state.dcClient.emit('whatsappDelete', {
                 id: msgKey.id,
-                jid: msgKey.remoteJid,
+                jid: utils.whatsapp.formatJid(msgKey.remoteJid),
             });
         }
     });


### PR DESCRIPTION
## Summary
- normalize JIDs when emitting WhatsApp delete events so Discord can locate messages