### PR TITLE
Capture terminal output to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 logs.txt
+terminal.log
 storage.db
 downloads/
 *.exe

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ page. Both methods use a small helper script that watches the process and
 restarts it automatically if it exits unexpectedly. Directly running
 `node src/index.js` will skip this helper and the bot won't restart on crashes.
 
+Runtime logs are written to `logs.txt`. Everything printed to the terminal is
+also saved to `terminal.log`, which can help diagnose issues when running on a
+headless server.
+
 Alternatively, you can run the bot using `docker-compose`. Copy `.env.example`
 to `.env`, put your Discord bot token in it and execute `docker compose up -d`.
 The compose file mounts the `storage` directory so data is kept between

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,6 +9,25 @@ const logger = pino({}, pino.multistream([
   { stream: pretty({ colorize: true }) },
 ]));
 
+// Capture everything printed to the terminal in a separate file
+const termLog = fs.createWriteStream('terminal.log', { flags: 'a' });
+const origStdoutWrite = process.stdout.write.bind(process.stdout);
+const origStderrWrite = process.stderr.write.bind(process.stderr);
+
+process.stdout.write = (chunk, encoding, cb) => {
+  termLog.write(chunk);
+  return origStdoutWrite(chunk, encoding, cb);
+};
+
+process.stderr.write = (chunk, encoding, cb) => {
+  termLog.write(chunk);
+  return origStderrWrite(chunk, encoding, cb);
+};
+
+process.on('exit', () => {
+  termLog.end();
+});
+
 const INDEX_PATH = path.join(__dirname, 'index.js');
 const RESTART_DELAY = 10000; // ms
 const MAX_RESTARTS = 5;
@@ -19,7 +38,13 @@ let child;
 let shuttingDown = false;
 
 function start() {
-  child = fork(INDEX_PATH, [], { stdio: 'inherit', execArgv: ['--no-deprecation'] });
+  child = fork(INDEX_PATH, [], {
+    stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
+    execArgv: ['--no-deprecation'],
+  });
+
+  if (child.stdout) child.stdout.pipe(process.stdout);
+  if (child.stderr) child.stderr.pipe(process.stderr);
 
   child.on('exit', (code, signal) => {
     if (shuttingDown) {


### PR DESCRIPTION
## Summary
- Mirror all stdout/stderr into `terminal.log` so console output is stored for later troubleshooting
- Document new `terminal.log` file and update `.gitignore`