### PR TITLE
fix deletion sync for multi-file messages

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -629,7 +629,7 @@ const whatsapp = {
         largeFile: msg.fileLength.low > 26214400,
       };
     } catch (err) {
-      if (err?.message?.includes('Unrecognised filter type')) {
+      if (err?.message?.includes('Unrecognised filter type') || err?.message?.includes('Unrecognized filter type')) {
         // Jimp sometimes throws this error when a PNG file is corrupted or malformed.
         // Avoid spamming the log with a stack trace for such cases.
         state.logger?.warn('Skipped sending attachment due to an invalid PNG file');


### PR DESCRIPTION
## Summary
- track all WhatsApp message IDs for albums when relaying to Discord
- ensure deleting a Discord message removes every corresponding WhatsApp message
- ignore corrupted PNG attachments without noisy stack traces