### PR TITLE
Stream WhatsApp media to temp files

### DIFF
--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -37,7 +37,11 @@ const sendWhatsappMessage = async (message, mediaFiles = [], messageIds = []) =>
       } else if (message.quote.file === -1 && !state.settings.LocalDownloads) {
         msgContent += "WA2DC Attention: Received a file, but it's over 8MB. Check WhatsApp on your phone or enable local downloads.";
       } else {
-        files.push(message.quote.file);
+        files.push({
+          attachment: fs.createReadStream(message.quote.file.path),
+          name: message.quote.file.name,
+          tmpPath: message.quote.file.path,
+        });
       }
     }
   }
@@ -53,7 +57,11 @@ const sendWhatsappMessage = async (message, mediaFiles = [], messageIds = []) =>
     else if (file === -1 && !state.settings.LocalDownloads) {
       msgContent += "WA2DC Attention: Received a file, but it's over 8MB. Check WhatsApp on your phone or enable local downloads.";
     } else if (file !== -1) {
-      files.push(file);
+      files.push({
+        attachment: fs.createReadStream(file.path),
+        name: file.name,
+        tmpPath: file.path,
+      });
     }
   }
 
@@ -108,6 +116,9 @@ const sendWhatsappMessage = async (message, mediaFiles = [], messageIds = []) =>
       }
       // store mapping for Discord -> first WhatsApp id for edits
       state.lastMessages[dcMessage.id] = message.id;
+    }
+    for (const f of files) {
+      if (f.tmpPath) fs.unlink(f.tmpPath, () => 0);
     }
   }
 };


### PR DESCRIPTION
## Summary
- use Baileys streaming option to write incoming WhatsApp media to a temporary file instead of buffering
- copy large downloads from the temp file to the configured download directory
- read Discord attachments from temp files and clean up after sending