### PR TITLE
Start local download server immediately and handle startup errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.22",
+      "version": "1.1.25",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -424,16 +424,20 @@ const commands = {
   },
   async enablelocaldownloadserver() {
     state.settings.LocalDownloadServer = true;
+    utils.ensureDownloadServer();
     await controlChannel.send(`Enabled local download server on port ${state.settings.LocalDownloadServerPort}.`);
   },
   async disablelocaldownloadserver() {
     state.settings.LocalDownloadServer = false;
+    utils.stopDownloadServer();
     await controlChannel.send('Disabled local download server.');
   },
   async setlocaldownloadserverport(_message, params) {
     const port = parseInt(params[0], 10);
     if (!Number.isNaN(port) && port > 0 && port <= 65535) {
       state.settings.LocalDownloadServerPort = port;
+      utils.stopDownloadServer();
+      utils.ensureDownloadServer();
       await controlChannel.send(`Set local download server port to ${port}.`);
     } else {
       await controlChannel.send('Please provide a valid port.');
@@ -442,6 +446,8 @@ const commands = {
   async setlocaldownloadserverhost(_message, params) {
     if (params[0]) {
       state.settings.LocalDownloadServerHost = params[0];
+      utils.stopDownloadServer();
+      utils.ensureDownloadServer();
       await controlChannel.send(`Set local download server host to ${params[0]}.`);
     } else {
       await controlChannel.send('Please provide a host name or IP.');
@@ -449,10 +455,14 @@ const commands = {
   },
   async enablehttpsdownloadserver() {
     state.settings.UseHttps = true;
+    utils.stopDownloadServer();
+    utils.ensureDownloadServer();
     await controlChannel.send('Enabled HTTPS for local download server.');
   },
   async disablehttpsdownloadserver() {
     state.settings.UseHttps = false;
+    utils.stopDownloadServer();
+    utils.ensureDownloadServer();
     await controlChannel.send('Disabled HTTPS for local download server.');
   },
   async sethttpscert(_message, params) {
@@ -461,6 +471,8 @@ const commands = {
       return;
     }
     [state.settings.HttpsKeyPath, state.settings.HttpsCertPath] = params;
+    utils.stopDownloadServer();
+    utils.ensureDownloadServer();
     await controlChannel.send(`Set HTTPS key path to ${params[0]} and cert path to ${params[1]}.`);
   },
   async enablepublishing() {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-    const version = 'v1.1.24';
+    const version = 'v1.1.25';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },
@@ -82,6 +82,8 @@ const whatsappHandler =  require('./whatsappHandler.js');
 
   state.settings = await storage.parseSettings();
   state.logger.info('Loaded settings.');
+
+  utils.ensureDownloadServer();
 
   clearInterval(autoSaver);
   autoSaver = setInterval(() => storage.save(), state.settings.autoSaveInterval * 1000);


### PR DESCRIPTION
## Summary
- start local download server as soon as it's enabled or configured
- add error handling and stop/start helpers for the download server