### PR TITLE
Bind download server to 0.0.0.0 and prune download dir

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,6 +110,11 @@ Sets the download directory.
     - `setDownloadDir C:\Users\<your username>\Downloads`: Downloads files to your usual Windows downloads folder
     - `setDownloadDir ./downloads`: Downloads files to Downloads folder in your bot's location.
 
+## setDownloadLimit
+Sets the maximum size for the download directory in gigabytes. Older files are removed when the limit is exceeded.
+- Format: `setDownloadLimit <gigabytes>`
+- Default: `0` (unlimited)
+
 ## setFileSizeLimit
 Changes the file size limit used to decide when to download files locally instead of uploading to Discord. Useful for servers with Nitro.
 - Format: `setFileSizeLimit <bytes>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.25",
+      "version": "1.1.26",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -413,6 +413,15 @@ const commands = {
     state.settings.DownloadDir = message.content.split(' ').slice(1).join(' ');
     await controlChannel.send(`Set download path to "${state.settings.DownloadDir}"`);
   },
+  async setdownloadlimit(_message, params) {
+    const gb = parseFloat(params[0]);
+    if (!Number.isNaN(gb) && gb >= 0) {
+      state.settings.DownloadDirLimitGB = gb;
+      await controlChannel.send(`Set download directory size limit to ${gb} GB.`);
+    } else {
+      await controlChannel.send('Please provide a valid size in gigabytes.');
+    }
+  },
   async setfilesizelimit(message) {
     const size = parseInt(message.content.split(' ')[1], 10);
     if (!Number.isNaN(size) && size > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-    const version = 'v1.1.25';
+    const version = 'v1.1.26';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,7 @@ module.exports = {
     LocalDownloads: false,
     LocalDownloadMessage: 'Downloaded a file larger than the upload limit, check it out at {url}',
     DownloadDir: './downloads',
+    DownloadDirLimitGB: 0,
     DiscordFileSizeLimit: 8 * 1024 * 1024,
     LocalDownloadServer: false,
     LocalDownloadServerHost: 'localhost',


### PR DESCRIPTION
## Summary
- Serve downloads on all interfaces while generating URLs with user-defined hostnames.
- Introduce configurable download directory size limit with automatic pruning of old files.
- Bump version to v1.1.26.