### PR TITLE
Support native Discord replies for WhatsApp quotes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -758,6 +758,7 @@ const whatsapp = {
     const file = await this.getFile(downloadCtx, qMsgType);
 
     return {
+      id: msg.contextInfo.stanzaId,
       name: this.jidToName(msg.contextInfo.participant || ''),
       content,
       file,

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -229,6 +229,7 @@ const connectToWhatsApp = async (retry = 1) => {
                     try {
                         const m = await client.sendMessage(jid, doc, options);
                         state.lastMessages[message.id] = m.key.id;
+                        state.lastMessages[m.key.id] = message.id;
                         state.sentMessages.add(m.key.id);
                     } catch (err) {
                         state.logger?.error(err);
@@ -238,6 +239,7 @@ const connectToWhatsApp = async (retry = 1) => {
                     try {
                         const m = await client.sendMessage(jid, doc);
                         state.lastMessages[message.id] = m.key.id;
+                        state.lastMessages[m.key.id] = message.id;
                         state.sentMessages.add(m.key.id);
                     } catch (err) {
                         state.logger?.error(err);
@@ -261,6 +263,7 @@ const connectToWhatsApp = async (retry = 1) => {
         try {
             const sent = await client.sendMessage(jid, content, options);
             state.lastMessages[message.id] = sent.key.id;
+            state.lastMessages[sent.key.id] = message.id;
             state.sentMessages.add(sent.key.id);
         } catch (err) {
             state.logger?.error(err);


### PR DESCRIPTION
## Summary
- link WhatsApp replies to original Discord messages using message references
- track message ID mappings in both directions
- expose quoted message IDs from WhatsApp parsing