### PR TITLE
add configurable read receipt options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -77,6 +77,22 @@ When enabled (enabled by default), deleting a message on one platform removes it
 When disabled, deleting a message on one platform will not affect the other, keeping the history.
 - Format: `disableDeletes`
 
+## enableReadReceipts
+Enables read receipts so you are notified when WhatsApp users read your messages.
+- Format: `enableReadReceipts`
+
+## disableReadReceipts
+Disables read receipts.
+- Format: `disableReadReceipts`
+
+## dmReadReceipts
+Sends read receipts as direct messages to the original Discord author instead of in the channel.
+- Format: `dmReadReceipts`
+
+## publicReadReceipts
+Posts a short reply in the channel when a WhatsApp message is read (auto-deletes after a few seconds).
+- Format: `publicReadReceipts`
+
 ## enableLocalDownloads
 When enabled, the bot downloads files larger than Discord's upload limit (default 8MB) to your download location. See `getDownloadDir` for your download location.
 - Format: `enableLocalDownloads`

--- a/src/state.js
+++ b/src/state.js
@@ -27,6 +27,8 @@ module.exports = {
     oneWay: 0b11,
     redirectWebhooks: false,
     DeleteMessages: true,
+    ReadReceipts: true,
+    ReadReceiptMode: 'public',
   },
   dcClient: null,
   waClient: null,
@@ -38,8 +40,19 @@ module.exports = {
   /**
    * Stores WhatsApp message IDs that originate from Discord so that
    * they are not echoed back to Discord when received from WhatsApp.
-   */
+  */
   sentMessages: new Set(),
+  /**
+   * Tracks Discord reactions that mirror WhatsApp reactions so we can
+   * update or remove them when WhatsApp users change their reaction.
+   * Structure: { [discordMessageId]: { [waJid]: emoji } }
+   */
+  reactions: {},
+  /**
+   * Stores WhatsApp message IDs for reactions originating from Discord
+   * to avoid echoing them back when WhatsApp sends confirmation events.
+   */
+  sentReactions: new Set(),
   goccRuns: {},
   updateInfo: null,
   version: '',


### PR DESCRIPTION
## Summary
- allow read receipts to be toggled and sent publicly or via DM
- DM authors when WhatsApp messages are read, citing the contact name
- document new read receipt commands