### PR TITLE
Handle missing message errors from Discord API

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -473,6 +473,10 @@ const discord = {
     try {
       return await webhook.editMessage(messageId, args);
     } catch (err) {
+      if (err.code === 10008 && err.message.includes('Unknown Message')) {
+        // message was already deleted or never existed
+        return null;
+      }
       if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
         delete state.goccRuns[jid];
         const channel = await this.getChannel(state.chats[jid].channelId);
@@ -492,6 +496,10 @@ const discord = {
     try {
       return await webhook.deleteMessage(messageId);
     } catch (err) {
+      if (err.code === 10008 && err.message.includes('Unknown Message')) {
+        // message was already removed, treat as success
+        return null;
+      }
       if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
         delete state.goccRuns[jid];
         const channel = await this.getChannel(state.chats[jid].channelId);


### PR DESCRIPTION
## Summary
- Avoid Discord API errors when attempting to edit or delete messages that no longer exist