### PR TITLE
Automate Docker image updates with Watchtower and CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ docker compose up -d
 The compose file mounts the `storage` directory so data is kept between
 container restarts.
 
+### Automatic updates
+
+A pre-built Docker image is published to the GitHub Container Registry on every push to `main`.
+The included compose file uses this image and adds a [Watchtower](https://github.com/containrrr/watchtower)
+service that checks for new versions every few minutes and restarts the bot
+when an update is available.
+
 ---
 
 For setup and commands, check out the [documentation](https://arespawn.github.io/WhatsAppToDiscord/)!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,17 @@
 name: wa2dc
 services:
   wa2dc:
-    build: .
+    image: ghcr.io/arespawn/whatsapptodiscord:latest
+    container_name: wa2dc
     volumes:
       - ./storage:/usr/local/WA2DC/storage
     env_file:
       - .env
     restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 wa2dc


### PR DESCRIPTION
## Summary
- publish Docker images on pushes using GitHub Actions
- use pre-built image in docker-compose and add Watchtower to auto-update
- document automatic Docker updates