### PR TITLE
Handle additional WhatsApp contact name fields

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -984,11 +984,25 @@ const whatsapp = {
   updateContacts(rawContacts) {
     const contacts = rawContacts.chats || rawContacts.contacts || rawContacts;
     for (const contact of contacts) {
-      const name = contact.name || contact.subject;
-      if (name) {
-        state.waClient.contacts[contact.id] = name;
-        state.contacts[contact.id] = name;
-      }
+      if (!contact?.id) continue;
+
+      const name = [
+        contact.name,
+        contact.verifiedName,
+        contact.formattedName,
+        contact.notify,
+        contact.pushName,
+        contact.pushname,
+        contact.shortName,
+        contact.subject,
+      ].find((value) => typeof value === 'string' && value.trim().length > 0);
+
+      if (!name) continue;
+
+      const trimmedName = name.trim();
+
+      state.waClient.contacts[contact.id] = trimmedName;
+      state.contacts[contact.id] = trimmedName;
     }
   },
   createDocumentContent(attachment) {


### PR DESCRIPTION
## Summary
- capture additional WhatsApp contact name fields when processing contact updates
- trim the stored names so Discord channels receive clean titles