### PR TITLE
chore: bump version to 1.1.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const storage = require('./storage.js');
 const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
-    const version = 'v1.1.30';
+    const version = 'v1.1.31';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },


### PR DESCRIPTION
## Summary
- bump the package version to 1.1.31 for the upcoming release
- update the runtime version string to match the new release number