### PR TITLE
Revert "Handle additional WhatsApp contact name fields"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1039,25 +1039,11 @@ const whatsapp = {
   updateContacts(rawContacts) {
     const contacts = rawContacts.chats || rawContacts.contacts || rawContacts;
     for (const contact of contacts) {
-      if (!contact?.id) continue;
-
-      const name = [
-        contact.name,
-        contact.verifiedName,
-        contact.formattedName,
-        contact.notify,
-        contact.pushName,
-        contact.pushname,
-        contact.shortName,
-        contact.subject,
-      ].find((value) => typeof value === 'string' && value.trim().length > 0);
-
-      if (!name) continue;
-
-      const trimmedName = name.trim();
-
-      state.waClient.contacts[contact.id] = trimmedName;
-      state.contacts[contact.id] = trimmedName;
+      const name = contact.name || contact.subject;
+      if (name) {
+        state.waClient.contacts[contact.id] = name;
+        state.contacts[contact.id] = name;
+      }
     }
   },
   createDocumentContent(attachment) {


### PR DESCRIPTION
Reverts arespawn/WhatsAppToDiscord#98 to fix resync rename original function, not sure why I did that sounded cool at the time.