### PR TITLE
Migrate to Baileys 7 RC8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Di
 
 Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now maintained by [arespawn](https://github.com/arespawn) with the blessing of the previous author.
 
+> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.0` ships the Baileys 7 migration and is considered **unstable**. Expect rapid changes and breaking issues until a stable tag is published.
+
 ## Requirements
 
 - Node.js 20 or higher

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ container restarts.
 
 ## Troubleshooting
 
-- **Duplicate Discord channels after the LID migration** – If a chat suddenly starts posting to a brand-new Discord channel, re-link it back to the original room from the control channel instead of editing `storage/chats.json` by hand. Run `link <contact> #old-channel` (or `start <jid> #old-channel` for a brand-new contact) and the bot will recreate its webhook inside the existing Discord channel, delete the stray webhook, and update the saved chat metadata. If you already created a webhook in the duplicate channel and just want to reuse it, open the Discord UI, edit that webhook, and change its target channel to the original room—the bridge will follow wherever that webhook points because it only stores the webhook id/token.
+- **Duplicate Discord channels after the LID migration** – If a chat suddenly starts posting to a brand-new Discord channel, re-link it back to the original room from the control channel instead of editing `storage/chats.json` by hand. Run `link --force <contact> #old-channel` (or `start <jid> #old-channel` for a brand-new contact) and the bot will recreate its webhook inside the existing Discord channel, delete the stray webhook, and update the saved chat metadata. If you just want to repoint the webhook that already lives inside the duplicate channel, run `move #duplicate-channel #old-channel --force` to move the WhatsApp conversation (and clean up the redundant webhook) in one step.
 
 ### Automatic updates
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ docker compose up -d
 The compose file mounts the `storage` directory so data is kept between
 container restarts.
 
+## Troubleshooting
+
+- **Duplicate Discord channels after the LID migration** – If a chat suddenly starts posting to a brand-new Discord channel, re-link it back to the original room from the control channel instead of editing `storage/chats.json` by hand. Run `link <contact> #old-channel` (or `start <jid> #old-channel` for a brand-new contact) and the bot will recreate its webhook inside the existing Discord channel, delete the stray webhook, and update the saved chat metadata. If you already created a webhook in the duplicate channel and just want to reuse it, open the Discord UI, edit that webhook, and change its target channel to the original room—the bridge will follow wherever that webhook points because it only stores the webhook id/token.
+
 ### Automatic updates
 
 A pre-built Docker image is published to the GitHub Container Registry on every push to `main`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Di
 
 Originally created by [Fatih Kilic](https://github.com/FKLC), now maintained by [arespawn](https://github.com/arespawn).
 
+> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.0` introduces the Baileys 7 migration and is **not yet stable**. Expect rapid updates and potential breaking changes until a stable release lands.
+
 ## Requirements
 
 - Node.js 20 or higher

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ The compose file mounts the `storage` directory so data is kept between containe
 
 ## Troubleshooting
 
-- **Duplicate Discord channels after the LID migration** – If a conversation suddenly starts flowing into a brand-new Discord channel, re-link it back to the original room via the control channel (`link <contact> #old-channel`) rather than editing files on disk. The bot will create a webhook inside the existing channel, clean up the stray webhook, and update its saved metadata. If you prefer to reuse the webhook that already exists in the duplicate channel, edit it in the Discord UI and change its target channel—the bridge keeps sending through whatever channel that webhook references because it only stores the id/token.
+- **Duplicate Discord channels after the LID migration** – If a conversation suddenly starts flowing into a brand-new Discord channel, re-link it back to the original room via the control channel (`link --force <contact> #old-channel`) rather than editing files on disk. The bot will create a webhook inside the existing channel, clean up the stray webhook, and update its saved metadata. If you prefer to move the webhook that already exists in the duplicate channel, run `move #duplicate-channel #old-channel --force` so the bot reuses that webhook and deletes the redundant channel mapping for you.
 
 ## Setup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,10 @@ docker compose up -d
 
 The compose file mounts the `storage` directory so data is kept between container restarts.
 
+## Troubleshooting
+
+- **Duplicate Discord channels after the LID migration** – If a conversation suddenly starts flowing into a brand-new Discord channel, re-link it back to the original room via the control channel (`link <contact> #old-channel`) rather than editing files on disk. The bot will create a webhook inside the existing channel, clean up the stray webhook, and update its saved metadata. If you prefer to reuse the webhook that already exists in the duplicate channel, edit it in the Discord UI and change its target channel—the bridge keeps sending through whatever channel that webhook references because it only stores the id/token.
+
 ## Setup
 
 The setup is short, but challenging for some. So, we explained every step in detail for your convenience, just [click here](setup.md) to get started.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,10 +16,20 @@ Starts a new conversation. It can be used with a name or a phone number.
 
 ## link
 Links an existing Discord text channel to a WhatsApp conversation without creating a new channel.
-- Format: `link <number with country code or name> #<channel name>`
+- Format: `link <number with country code or name> #<channel name> [--force|-f]`
 - Examples:
     - `link 11231231234 #existing-chat`: This would connect the WhatsApp conversation with +1 123 123 1234 to the mentioned Discord channel.
     - `link John Doe #team-chat`: This would connect the WhatsApp conversation with John Doe to the mentioned Discord channel.
+- Tips:
+    - Add `--force` (or `-f`) to override a Discord channel that's already linked to a different WhatsApp conversation.
+
+## move
+Moves an existing WhatsApp link (and its webhook) from one Discord channel to another without editing files manually.
+- Format: `move #<current channel> #<new channel> [--force|-f]`
+- Examples:
+    - `move #duplicate-channel #original-room --force`: This reassigns the WhatsApp chat that is currently writing in `#duplicate-channel` so it posts in `#original-room` instead (and deletes the redundant webhook).
+- Tips:
+    - Use `--force` (or `-f`) when the destination channel is already linked to some other WhatsApp conversation.
 
 ## list
 Lists your contacts and groups.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@whiskeysockets/baileys": "^6.7.21",
+        "@whiskeysockets/baileys": "^7.0.0-rc.6",
         "discord.js": "^13.16.0",
         "link-preview-js": "^3.0.0",
         "pino": "^8.14.1",
@@ -1123,18 +1123,19 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "6.7.21",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-6.7.21.tgz",
-      "integrity": "sha512-xx9OHd6jlPiu5yZVuUdwEgFNAOXiEG8sULHxC6XfzNwssnwxnA9Lp44pR05H621GQcKyCfsH33TGy+Na6ygX4w==",
+      "version": "7.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.6.tgz",
+      "integrity": "sha512-vSARE9ftvNwN2vttcFGhwqag2K8MRY35CD5zd1uMPSUQ0eomfAUVreNwXBUO1XO2eBExOW2N+mSmNGPn6mnqDQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
         "async-mutex": "^0.5.0",
-        "axios": "^1.6.0",
         "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
+        "lru-cache": "^11.1.0",
         "music-metadata": "^11.7.0",
+        "p-queue": "^9.0.0",
         "pino": "^9.6",
         "protobufjs": "^7.2.4",
         "ws": "^8.13.0"
@@ -1573,16 +1574,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/b4a": {
@@ -3480,6 +3471,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3690,25 +3687,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -5073,6 +5051,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5715,6 +5702,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.0.1.tgz",
+      "integrity": "sha512-RhBdVhSwJb7Ocn3e8ULk4NMwBEuOxe+1zcgphUy9c2e5aR/xbEsdVXxHJ3lynw6Qiqu7OINEyHlZkiblEpaq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -6339,11 +6354,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@whiskeysockets/baileys": "^7.0.0-rc.7",
+        "@whiskeysockets/baileys": "^7.0.0-rc.8",
         "discord.js": "^13.16.0",
         "link-preview-js": "^3.0.0",
         "pino": "^8.14.1",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "7.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.7.tgz",
-      "integrity": "sha512-s7JHBPLUmnbA2PhhCJwZau+H6xRFH7E+nBS6OzYjonAOddO4At0BVkjn/wRwW9nsd4LqiWo2HpabpoMOi9xe3g==",
+      "version": "7.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.8.tgz",
+      "integrity": "sha512-yH2J0rmsmRf8gDWI6e8IFH0okGJKtNBSLa3iT65tsxbwtC/rB02P36WGzX4fWncW9KP4bi+vr71sXdaiWKSnig==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",
-        "@whiskeysockets/baileys": "^7.0.0-rc.6",
+        "@whiskeysockets/baileys": "^7.0.0-rc.7",
         "discord.js": "^13.16.0",
         "link-preview-js": "^3.0.0",
         "pino": "^8.14.1",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "version": "7.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.6.tgz",
-      "integrity": "sha512-vSARE9ftvNwN2vttcFGhwqag2K8MRY35CD5zd1uMPSUQ0eomfAUVreNwXBUO1XO2eBExOW2N+mSmNGPn6mnqDQ==",
+      "version": "7.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.7.tgz",
+      "integrity": "sha512-s7JHBPLUmnbA2PhhCJwZau+H6xRFH7E+nBS6OzYjonAOddO4At0BVkjn/wRwW9nsd4LqiWo2HpabpoMOi9xe3g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "1.1.35",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "1.1.35",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@whiskeysockets/baileys": "^7.0.0-rc.7",
+    "@whiskeysockets/baileys": "^7.0.0-rc.8",
     "discord.js": "^13.16.0",
     "link-preview-js": "^3.0.0",
     "pino": "^8.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "1.1.35",
+  "version": "2.0.0-alpha.0",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@whiskeysockets/baileys": "^7.0.0-rc.6",
+    "@whiskeysockets/baileys": "^7.0.0-rc.7",
     "discord.js": "^13.16.0",
     "link-preview-js": "^3.0.0",
     "pino": "^8.14.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wa2dc",
   "version": "1.1.35",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
+  "type": "module",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/runner.js",
@@ -15,7 +16,7 @@
   },
   "dependencies": {
     "@adiwajshing/keyed-db": "^0.2.4",
-    "@whiskeysockets/baileys": "^6.7.21",
+    "@whiskeysockets/baileys": "^7.0.0-rc.6",
     "discord.js": "^13.16.0",
     "link-preview-js": "^3.0.0",
     "pino": "^8.14.1",

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1005,7 +1005,8 @@ const commands = {
   async checkupdate() {
     await utils.updater.run(state.version, { prompt: false });
     if (state.updateInfo) {
-      await controlChannel.send(
+      await utils.discord.sendPartitioned(
+        controlChannel,
         `A new version is available ${state.updateInfo.currVer} -> ${state.updateInfo.version}.\n` +
         `See ${state.updateInfo.url}\n` +
         `Changelog: ${state.updateInfo.changes}\nType \`update\` to apply or \`skipUpdate\` to ignore.`

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ if (!globalThis.crypto) {
 }
 
 (async () => {
-    const version = 'v1.1.35';
+    const version = 'v2.0.0-alpha.0';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,17 @@
-const nodeCrypto = require('crypto');
+import nodeCrypto from 'crypto';
+import pino from 'pino';
+import pretty from 'pino-pretty';
+import fs from 'fs';
+
+import discordHandler from './discordHandler.js';
+import state from './state.js';
+import utils from './utils.js';
+import storage from './storage.js';
+import whatsappHandler from './whatsappHandler.js';
+
 if (!globalThis.crypto) {
   globalThis.crypto = nodeCrypto.webcrypto;
 }
-const pino = require('pino');
-const pretty = require('pino-pretty');
-const fs = require('fs');
-
-const discordHandler =  require('./discordHandler.js');
-const state =  require('./state.js');
-const utils =  require('./utils.js');
-const storage = require('./storage.js');
-const whatsappHandler =  require('./whatsappHandler.js');
 
 (async () => {
     const version = 'v1.1.35';

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,8 @@ if (!globalThis.crypto) {
 
   if (state.updateInfo) {
     const ctrl = await utils.discord.getControlChannel();
-    await ctrl?.send(
+    await utils.discord.sendPartitioned(
+      ctrl,
       `A new version is available ${state.updateInfo.currVer} -> ${state.updateInfo.version}.\n` +
       `See ${state.updateInfo.url}\n` +
       `Changelog: ${state.updateInfo.changes}\nType \`update\` to apply or \`skipUpdate\` to ignore.`
@@ -152,7 +153,8 @@ if (!globalThis.crypto) {
     await utils.updater.run(version, { prompt: false });
     if (state.updateInfo) {
       const ch = await utils.discord.getControlChannel();
-      await ch?.send(
+      await utils.discord.sendPartitioned(
+        ch,
         `A new version is available ${state.updateInfo.currVer} -> ${state.updateInfo.version}.\n` +
         `See ${state.updateInfo.url}\n` +
         `Changelog: ${state.updateInfo.changes}\nType \`update\` to apply or \`skipUpdate\` to ignore.`

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,8 +1,12 @@
-const { fork } = require('child_process');
-const path = require('path');
-const pino = require('pino');
-const pretty = require('pino-pretty');
-const fs = require('fs');
+import { fork } from 'child_process';
+import path from 'path';
+import pino from 'pino';
+import pretty from 'pino-pretty';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const logger = pino({}, pino.multistream([
   { stream: pino.destination('logs.txt') },

--- a/src/state.js
+++ b/src/state.js
@@ -58,4 +58,19 @@ const state = {
   version: '',
 };
 
+export const settings = state.settings;
+export const dcClient = () => state.dcClient;
+export const waClient = () => state.waClient;
+export const chats = state.chats;
+export const contacts = state.contacts;
+export const startTime = () => state.startTime;
+export const logger = () => state.logger;
+export const lastMessages = () => state.lastMessages;
+export const sentMessages = state.sentMessages;
+export const reactions = state.reactions;
+export const sentReactions = state.sentReactions;
+export const goccRuns = state.goccRuns;
+export const updateInfo = () => state.updateInfo;
+export const version = () => state.version;
+
 export default state;

--- a/src/state.js
+++ b/src/state.js
@@ -1,4 +1,4 @@
-module.exports = {
+const state = {
   settings: {
     Whitelist: [],
     DiscordPrefixText: null,
@@ -57,3 +57,5 @@ module.exports = {
   updateInfo: null,
   version: '',
 };
+
+export default state;

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,9 +1,11 @@
-const readline = require('readline');
-const fs = require('fs/promises');
-const path = require('path');
-const { Client, Intents } = require('discord.js');
+import readline from 'readline';
+import fs from 'fs/promises';
+import path from 'path';
+import discordJs from 'discord.js';
 
-const state = require('./state.js');
+import state from './state.js';
+
+const { Client, Intents } = discordJs;
 
 const bidirectionalMap = (capacity, data = {}) => {
   const keys = Object.keys(data);
@@ -136,4 +138,4 @@ const setup = {
   },
 };
 
-module.exports = storage;
+export default storage;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,20 @@
-const { Webhook, MessageAttachment } = require('discord.js');
-const { downloadMediaMessage, downloadContentFromMessage } = require('@whiskeysockets/baileys');
-const readline = require('readline');
-const QRCode = require('qrcode');
-const crypto = require('crypto');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { pipeline } = require('stream/promises');
-const { pathToFileURL } = require('url');
-const http = require('http');
-const https = require('https');
-const child_process = require('child_process');
+import discordJs from 'discord.js';
+import { downloadMediaMessage, downloadContentFromMessage } from '@whiskeysockets/baileys';
+import readline from 'readline';
+import QRCode from 'qrcode';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import { pathToFileURL } from 'url';
+import http from 'http';
+import https from 'https';
+import childProcess from 'child_process';
 
-const state = require('./state.js');
+import state from './state.js';
+
+const { Webhook, MessageAttachment } = discordJs;
 
 const downloadTokens = new Map();
 
@@ -449,7 +451,7 @@ const sqliteToJson = {
     if (os.platform() !== 'win32') {
       exeName = './' + exeName;
     }
-    const child = child_process.spawnSync(exeName, [this._dbPath, '"SELECT * FROM WA2DC"'], { shell: true });
+    const child = childProcess.spawnSync(exeName, [this._dbPath, '"SELECT * FROM WA2DC"'], { shell: true });
 
     const rows = child.stdout.toString().trim().split('\n');
     for (let i = 0; i < rows.length; i++) {
@@ -541,19 +543,21 @@ const discord = {
   },
   _unfinishedGoccCalls: 0,
   async getOrCreateChannel(jid) {
-    if (state.goccRuns[jid]) { return state.goccRuns[jid]; }
+    const normalizedJid = whatsapp.formatJid(jid);
+    if (!normalizedJid) return null;
+    if (state.goccRuns[normalizedJid]) { return state.goccRuns[normalizedJid]; }
     let resolve;
-    state.goccRuns[jid] = new Promise((res) => {
+    state.goccRuns[normalizedJid] = new Promise((res) => {
       resolve = res;
     });
-    if (state.chats[jid]) {
-      const webhook = ensureWebhookReplySupport(new Webhook(state.dcClient, state.chats[jid]));
+    if (state.chats[normalizedJid]) {
+      const webhook = ensureWebhookReplySupport(new Webhook(state.dcClient, state.chats[normalizedJid]));
       resolve(webhook);
       return webhook;
     }
 
     this._unfinishedGoccCalls++;
-    const name = whatsapp.jidToName(jid);
+    const name = whatsapp.jidToName(normalizedJid);
     const channel = await this.createChannel(name).catch((err) => {
       if (err.code === 50035) {
         return this.createChannel('invalid-name');
@@ -561,7 +565,7 @@ const discord = {
       throw err;
     });
     const webhook = ensureWebhookReplySupport(await channel.createWebhook('WA2DC'));
-    state.chats[jid] = {
+    state.chats[normalizedJid] = {
       id: webhook.id,
       type: webhook.type,
       token: webhook.token,
@@ -815,6 +819,7 @@ const discord = {
     return await webhook.send(fallbackArgs);
   },
   async safeWebhookEdit(webhook, messageId, args, jid) {
+    const normalizedJid = whatsapp.formatJid(jid);
     try {
       return await webhook.editMessage(messageId, args);
     } catch (err) {
@@ -823,21 +828,26 @@ const discord = {
         return null;
       }
       if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
-        delete state.goccRuns[jid];
-        const channel = await this.getChannel(state.chats[jid].channelId);
+        if (normalizedJid) {
+          delete state.goccRuns[normalizedJid];
+        }
+        const channel = await this.getChannel(state.chats[normalizedJid]?.channelId);
         webhook = ensureWebhookReplySupport(await channel.createWebhook('WA2DC'));
-        state.chats[jid] = {
-          id: webhook.id,
-          type: webhook.type,
-          token: webhook.token,
-          channelId: webhook.channelId,
-        };
+        if (normalizedJid) {
+          state.chats[normalizedJid] = {
+            id: webhook.id,
+            type: webhook.type,
+            token: webhook.token,
+            channelId: webhook.channelId,
+          };
+        }
         return await webhook.editMessage(messageId, args);
       }
       throw err;
     }
   },
   async safeWebhookDelete(webhook, messageId, jid) {
+    const normalizedJid = whatsapp.formatJid(jid);
     try {
       return await webhook.deleteMessage(messageId);
     } catch (err) {
@@ -846,15 +856,19 @@ const discord = {
         return null;
       }
       if (err.code === 10015 && err.message.includes('Unknown Webhook')) {
-        delete state.goccRuns[jid];
-        const channel = await this.getChannel(state.chats[jid].channelId);
+        if (normalizedJid) {
+          delete state.goccRuns[normalizedJid];
+        }
+        const channel = await this.getChannel(state.chats[normalizedJid]?.channelId);
         webhook = ensureWebhookReplySupport(await channel.createWebhook('WA2DC'));
-        state.chats[jid] = {
-          id: webhook.id,
-          type: webhook.type,
-          token: webhook.token,
-          channelId: webhook.channelId,
-        };
+        if (normalizedJid) {
+          state.chats[normalizedJid] = {
+            id: webhook.id,
+            type: webhook.type,
+            token: webhook.token,
+            channelId: webhook.channelId,
+          };
+        }
         return await webhook.deleteMessage(messageId);
       }
       throw err;
@@ -1020,11 +1034,64 @@ const discord = {
 };
 
 const whatsapp = {
-  jidToPhone(jid) {
-    return jid.split(':')[0].split('@')[0];
+  jidToPhone(jid = '') {
+    if (!jid) return '';
+    return String(jid).split(':')[0].split('@')[0];
   },
   formatJid(jid) {
-    return `${this.jidToPhone(jid)}@${jid.split('@')[1]}`;
+    if (!jid) return null;
+    const [userPart, serverPart] = String(jid).split('@');
+    if (!serverPart) return String(jid);
+    const cleanUser = userPart.split(':')[0];
+    return `${cleanUser}@${serverPart}`;
+  },
+  migrateLegacyJid(oldJid, newJid) {
+    const legacy = this.formatJid(oldJid);
+    const fresh = this.formatJid(newJid);
+    if (!legacy || !fresh || legacy === fresh) return;
+    const migrateKey = (container) => {
+      if (!container || !Object.prototype.hasOwnProperty.call(container, legacy)) return;
+      if (!Object.prototype.hasOwnProperty.call(container, fresh)) {
+        container[fresh] = container[legacy];
+      }
+      delete container[legacy];
+    };
+    migrateKey(state.chats);
+    migrateKey(state.contacts);
+    migrateKey(state.goccRuns);
+    const whitelist = state.settings?.Whitelist;
+    if (Array.isArray(whitelist) && whitelist.length) {
+      const normalized = whitelist.map((jid) => {
+        const formatted = this.formatJid(jid);
+        return formatted === legacy ? fresh : formatted;
+      });
+      state.settings.Whitelist = [...new Set(normalized.filter(Boolean))];
+    }
+  },
+  resolveKnownJid(...candidates) {
+    const flat = candidates.flat().filter(Boolean);
+    for (const jid of flat) {
+      if (state.chats[jid]) return jid;
+    }
+    for (const jid of flat) {
+      if (state.contacts[jid]) return jid;
+    }
+    return flat.find(Boolean) || null;
+  },
+  getChatJidCandidates(rawMsg = {}) {
+    const { key = {} } = rawMsg;
+    const remoteJid = this.formatJid(
+      key.remoteJid
+      || rawMsg.chatId
+      || rawMsg.attrs?.from
+      || rawMsg.from
+      || rawMsg.jid,
+    );
+    const remoteJidAlt = this.formatJid(key.remoteJidAlt || rawMsg.remoteJidAlt);
+    const candidates = [];
+    if (remoteJid) candidates.push(remoteJid);
+    if (remoteJidAlt && !candidates.includes(remoteJidAlt)) candidates.push(remoteJidAlt);
+    return candidates;
   },
   isMe(myJID, jid) {
     return jid.startsWith(this.jidToPhone(myJID)) && !jid.endsWith('@g.us');
@@ -1034,9 +1101,18 @@ const whatsapp = {
     return state.waClient.contacts[this.formatJid(jid)] || pushName || this.jidToPhone(jid);
   },
   toJid(name) {
+    if (!name) return null;
+    const trimmed = String(name).trim();
     // eslint-disable-next-line no-restricted-globals
-    if (!isNaN(name)) { return `${name}@s.whatsapp.net`; }
-    return Object.keys(state.waClient.contacts).find((key) => state.waClient.contacts[key].toLowerCase().trim() === name.toLowerCase().trim());
+    if (!isNaN(trimmed)) { return this.formatJid(`${trimmed}@s.whatsapp.net`); }
+    if (trimmed.includes('@')) {
+      return this.formatJid(trimmed);
+    }
+    const normalized = trimmed.toLowerCase();
+    const match = Object.keys(state.waClient.contacts)
+      .find((key) => state.waClient.contacts[key]
+        && state.waClient.contacts[key].toLowerCase().trim() === normalized);
+    return this.formatJid(match);
   },
   contacts() {
     return Object.values(state.waClient.contacts);
@@ -1070,33 +1146,24 @@ const whatsapp = {
       .send({ files: [new MessageAttachment(await QRCode.toBuffer(qrString), 'qrcode.png')] });
   },
   getChannelJid(rawMsg) {
-    const rawJid = rawMsg?.key?.remoteJid
-      || rawMsg?.chatId
-      || rawMsg?.attrs?.from
-      || rawMsg?.from
-      || rawMsg?.jid;
-
-    if (!rawJid) return null;
-
-    const formattedJid = this.formatJid(rawJid);
-    if (!formattedJid) return formattedJid;
-
-    if (state.chats[formattedJid]) {
-      return formattedJid;
+    const [primary, alternate] = this.getChatJidCandidates(rawMsg);
+    if (primary && alternate) {
+      this.migrateLegacyJid(alternate, primary);
     }
-
-    const phone = this.jidToPhone(formattedJid);
-    for (const existingJid of Object.keys(state.chats)) {
-      if (this.jidToPhone(existingJid) === phone) {
-        return existingJid;
-      }
-    }
-
-    return formattedJid;
+    return this.resolveKnownJid(primary, alternate);
   },
   getSenderJid(rawMsg, fromMe) {
     if (fromMe) { return this.formatJid(state.waClient.user.id); }
-    return this.formatJid(rawMsg?.key?.participant || rawMsg?.key?.remoteJid || rawMsg?.chatId || rawMsg?.jid);
+    const { key = {} } = rawMsg || {};
+    const participant = this.formatJid(key.participant || rawMsg?.participant);
+    const participantAlt = this.formatJid(key.participantAlt || rawMsg?.participantAlt || key.remoteJidAlt);
+    if (participant && participantAlt) {
+      this.migrateLegacyJid(participantAlt, participant);
+    }
+    const resolved = this.resolveKnownJid(participant, participantAlt);
+    if (resolved) return resolved;
+    const [chatJid] = this.getChatJidCandidates(rawMsg);
+    return chatJid;
   },
   getSenderName(rawMsg) {
     return this.jidToName(this.getSenderJid(rawMsg, rawMsg.key.fromMe), rawMsg.pushName);
@@ -1126,12 +1193,16 @@ const whatsapp = {
     const content = this.getContent(message, nMsgType, qMsgType);
     let file = null;
     if (qMsgType && context?.stanzaId) {
+      const quoteParticipant = this.formatJid(context?.participant || context?.participantAlt);
+      if (context?.participant && context?.participantAlt) {
+        this.migrateLegacyJid(context.participantAlt, context.participant);
+      }
       const downloadCtx = {
         key: {
-          remoteJid: rawMsg.key.remoteJid,
+          remoteJid: this.getChannelJid(rawMsg) || rawMsg.key.remoteJid,
           id: context.stanzaId,
           fromMe: rawMsg.key.fromMe,
-          participant: context.participant,
+          participant: quoteParticipant,
         },
         message: qMsg,
       };
@@ -1139,7 +1210,7 @@ const whatsapp = {
     }
 
     const quote = {
-      name: this.jidToName(context?.participant || ''),
+      name: this.jidToName(this.resolveKnownJid(context?.participant, context?.participantAlt) || ''),
       content,
       file,
     };
@@ -1214,7 +1285,11 @@ const whatsapp = {
     }
   },
   inWhitelist(rawMsg) {
-    return state.settings.Whitelist.length === 0 || state.settings.Whitelist.includes(rawMsg?.key?.remoteJid || rawMsg.chatId);
+    const whitelist = state.settings.Whitelist || [];
+    if (!whitelist.length) return true;
+    const normalized = whitelist.map((jid) => this.formatJid(jid)).filter(Boolean);
+    const candidates = this.getChatJidCandidates(rawMsg);
+    return candidates.some((jid) => normalized.includes(jid));
   },
   getTimestamp(rawMsg) {
     if (rawMsg?.messageTimestamp) return rawMsg.messageTimestamp;
@@ -1279,11 +1354,22 @@ const whatsapp = {
   updateContacts(rawContacts) {
     const contacts = rawContacts.chats || rawContacts.contacts || rawContacts;
     for (const contact of contacts) {
-      const name = contact.name || contact.subject;
-      if (name) {
-        state.waClient.contacts[contact.id] = name;
-        state.contacts[contact.id] = name;
+      const name = contact?.name || contact?.subject;
+      if (!name) continue;
+      const preferredId = this.formatJid(contact?.id);
+      let alternateId = null;
+      if (contact?.phoneNumber) {
+        alternateId = this.formatJid(`${contact.phoneNumber}@s.whatsapp.net`);
+      } else if (contact?.lid) {
+        alternateId = this.formatJid(contact.lid);
       }
+      if (preferredId && alternateId) {
+        this.migrateLegacyJid(alternateId, preferredId);
+      }
+      const targetId = preferredId || alternateId;
+      if (!targetId) continue;
+      state.waClient.contacts[targetId] = name;
+      state.contacts[targetId] = name;
     }
   },
   createDocumentContent(attachment) {
@@ -1397,7 +1483,7 @@ const ui = {
   },
 };
 
-module.exports = {
+const utils = {
   updater,
   discord,
   whatsapp,
@@ -1405,3 +1491,5 @@ module.exports = {
   ensureDownloadServer,
   stopDownloadServer,
 };
+
+export default utils;

--- a/src/utils.js
+++ b/src/utils.js
@@ -484,6 +484,14 @@ const discord = {
   partitionText(text) {
     return text.match(/(.|[\r\n]){1,2000}/g) || [];
   },
+  async sendPartitioned(channel, text) {
+    if (!channel || !text) return;
+    const parts = this.partitionText(text);
+    for (const part of parts) {
+      // eslint-disable-next-line no-await-in-loop
+      await channel.send(part);
+    }
+  },
   convertWhatsappFormatting(text = '') {
     if (!text) return text;
     let converted = text;

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -101,7 +101,9 @@ const connectToWhatsApp = async (retry = 1) => {
         }
     });
     client.ev.on('creds.update', saveState);
-    ['chats.set', 'contacts.set', 'chats.upsert', 'chats.update', 'contacts.upsert', 'contacts.update', 'groups.upsert', 'groups.update'].forEach((eventName) => client.ev.on(eventName, utils.whatsapp.updateContacts));
+    const contactUpdater = utils.whatsapp.updateContacts.bind(utils.whatsapp);
+    ['chats.set', 'contacts.set', 'chats.upsert', 'chats.update', 'contacts.upsert', 'contacts.update', 'groups.upsert', 'groups.update']
+      .forEach((eventName) => client.ev.on(eventName, contactUpdater));
 
     client.ev.on('messages.upsert', async (update) => {
         if (['notify', 'append'].includes(update.type)) {

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -119,12 +119,12 @@ const connectToWhatsApp = async (retry = 1) => {
                 const [nMsgType, message] = utils.whatsapp.getMessage(rawMessage, messageType);
                 state.dcClient.emit('whatsappMessage', {
                     id: utils.whatsapp.getId(rawMessage),
-                    name: utils.whatsapp.getSenderName(rawMessage),
+                    name: await utils.whatsapp.getSenderName(rawMessage),
                     content: utils.whatsapp.getContent(message, nMsgType, messageType),
                     quote: await utils.whatsapp.getQuote(rawMessage),
                     file: await utils.whatsapp.getFile(rawMessage, messageType),
                     profilePic: await utils.whatsapp.getProfilePic(rawMessage),
-                    channelJid: utils.whatsapp.getChannelJid(rawMessage),
+                    channelJid: await utils.whatsapp.getChannelJid(rawMessage),
                     isGroup: utils.whatsapp.isGroup(rawMessage),
                     isForwarded: utils.whatsapp.isForwarded(message),
                     isEdit: messageType === 'editedMessage'
@@ -148,9 +148,9 @@ const connectToWhatsApp = async (retry = 1) => {
 
             state.dcClient.emit('whatsappReaction', {
                 id: msgId,
-                jid: utils.whatsapp.getChannelJid(rawReaction),
+                jid: await utils.whatsapp.getChannelJid(rawReaction),
                 text: rawReaction.reaction.text,
-                author: utils.whatsapp.getSenderJid(rawReaction, rawReaction.key.fromMe),
+                author: await utils.whatsapp.getSenderJid(rawReaction, rawReaction.key.fromMe),
             });
             const ts = utils.whatsapp.getTimestamp(rawReaction);
             if (ts > state.startTime) state.startTime = ts;
@@ -161,7 +161,7 @@ const connectToWhatsApp = async (retry = 1) => {
         const keys = 'keys' in updates ? updates.keys : updates;
         for (const key of keys) {
             if (!utils.whatsapp.inWhitelist({ key })) continue;
-            const jid = utils.whatsapp.getChannelJid({ key });
+            const jid = await utils.whatsapp.getChannelJid({ key });
             if (!jid) continue;
             state.dcClient.emit('whatsappDelete', {
                 id: key.id,
@@ -176,7 +176,7 @@ const connectToWhatsApp = async (retry = 1) => {
                 [WAMessageStatus.READ, WAMessageStatus.PLAYED].includes(update.status)) {
                 state.dcClient.emit('whatsappRead', {
                     id: key.id,
-                    jid: utils.whatsapp.getChannelJid({ key }),
+                    jid: await utils.whatsapp.getChannelJid({ key }),
                 });
             }
 
@@ -189,7 +189,7 @@ const connectToWhatsApp = async (retry = 1) => {
             if (!utils.whatsapp.inWhitelist({ key: msgKey })) continue;
             state.dcClient.emit('whatsappDelete', {
                 id: msgKey.id,
-                jid: utils.whatsapp.getChannelJid({ key: msgKey }),
+                jid: await utils.whatsapp.getChannelJid({ key: msgKey }),
             });
         }
     });
@@ -200,7 +200,7 @@ const connectToWhatsApp = async (retry = 1) => {
                 return;
 
             state.dcClient.emit('whatsappCall', {
-                jid: utils.whatsapp.getChannelJid(call),
+                jid: await utils.whatsapp.getChannelJid(call),
                 call,
             });
             const ts = utils.whatsapp.getTimestamp(call);
@@ -222,7 +222,7 @@ const connectToWhatsApp = async (retry = 1) => {
                 name: "WA2DC",
                 content: "[BOT] " + (removed ? "User removed their profile picture!" : "User changed their profile picture!"),
                 profilePic: utils.whatsapp._profilePicsCache[contact.id],
-                channelJid: utils.whatsapp.getChannelJid({ chatId: contact.id }),
+                channelJid: await utils.whatsapp.getChannelJid({ chatId: contact.id }),
                 isGroup: contact.id.endsWith('@g.us'),
                 isForwarded: false,
                 file: removed ? null : await client.profilePictureUrl(contact.id, 'image').catch(() => null),
@@ -255,7 +255,7 @@ const connectToWhatsApp = async (retry = 1) => {
             name: "WA2DC",
             content: "[BOT] User changed their status to: " + status,
             profilePic: utils.whatsapp._profilePicsCache[update.attrs.from],
-            channelJid: utils.whatsapp.getChannelJid({ chatId: update.attrs.from }),
+            channelJid: await utils.whatsapp.getChannelJid({ chatId: update.attrs.from }),
             isGroup: update.attrs.from.endsWith('@g.us'),
             isForwarded: false,
         });

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -5,7 +5,20 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def ensure_node_deps():
+    baileys_path = ROOT / "node_modules" / "@whiskeysockets" / "baileys"
+    if baileys_path.exists():
+        return
+
+    subprocess.run(
+        ["npm", "ci", "--ignore-scripts", "--omit=dev"],
+        check=True,
+        cwd=ROOT,
+    )
+
+
 def node_eval(code: str) -> str:
+    ensure_node_deps()
     result = subprocess.run(
         ["node", "-e", code],
         capture_output=True,

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -1,0 +1,43 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def node_eval(code: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", code],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_multi_file_auth_state_handles_tctoken(tmp_path):
+    auth_dir = tmp_path / "auth"
+    auth_dir.mkdir()
+    script = f"""
+const fs = require('node:fs');
+(async () => {{
+  const {{ useMultiFileAuthState }} = await import('@whiskeysockets/baileys');
+  const dir = {json.dumps(str(auth_dir))};
+  const {{ state }} = await useMultiFileAuthState(dir);
+  await state.keys.set({{ tctoken: {{ test: Buffer.from('rc8') }} }});
+  const stored = await state.keys.get('tctoken', ['test']);
+  const files = fs.readdirSync(dir).filter((name) => name.startsWith('tctoken-'));
+  console.log(JSON.stringify({{
+    stored: stored.test ? stored.test.toString('base64') : null,
+    files,
+  }}));
+}})().catch((err) => {{
+  console.error(err);
+  process.exit(1);
+}});
+"""
+    output = node_eval(script)
+    payload = json.loads(output)
+    assert payload["stored"] == "cmM4"
+    assert any(name.startswith("tctoken-") for name in payload["files"])

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -16,7 +16,7 @@ def node_eval(code: str) -> str:
     return result.stdout.strip()
 
 
-def test_multi_file_auth_state_handles_tctoken(tmp_path):
+def test_multi_file_auth_state_handles_new_signal_entries(tmp_path):
     auth_dir = tmp_path / "auth"
     auth_dir.mkdir()
     script = f"""
@@ -25,11 +25,22 @@ const fs = require('node:fs');
   const {{ useMultiFileAuthState }} = await import('@whiskeysockets/baileys');
   const dir = {json.dumps(str(auth_dir))};
   const {{ state }} = await useMultiFileAuthState(dir);
-  await state.keys.set({{ tctoken: {{ test: Buffer.from('rc8') }} }});
+  await state.keys.set({{
+    tctoken: {{ test: Buffer.from('rc8') }},
+    'lid-mapping': {{ pn: '161040050426060:29@lid' }},
+    'device-index': {{ primary: Buffer.from('device-index') }},
+    'device-list': {{ primary: Buffer.from('device-list') }},
+  }});
   const stored = await state.keys.get('tctoken', ['test']);
-  const files = fs.readdirSync(dir).filter((name) => name.startsWith('tctoken-'));
+  const lidMapping = await state.keys.get('lid-mapping', ['pn']);
+  const deviceIndex = await state.keys.get('device-index', ['primary']);
+  const deviceList = await state.keys.get('device-list', ['primary']);
+  const files = fs.readdirSync(dir).filter((name) => name.match(/^(tctoken|lid-mapping|device-(index|list))/));
   console.log(JSON.stringify({{
     stored: stored.test ? stored.test.toString('base64') : null,
+    lidMapping,
+    deviceIndex: deviceIndex.primary ? deviceIndex.primary.toString('utf8') : null,
+    deviceList: deviceList.primary ? deviceList.primary.toString('utf8') : null,
     files,
   }}));
 }})().catch((err) => {{
@@ -40,4 +51,10 @@ const fs = require('node:fs');
     output = node_eval(script)
     payload = json.loads(output)
     assert payload["stored"] == "cmM4"
+    assert payload["lidMapping"].get("pn") == "161040050426060:29@lid"
+    assert payload["deviceIndex"] == "device-index"
+    assert payload["deviceList"] == "device-list"
     assert any(name.startswith("tctoken-") for name in payload["files"])
+    assert any(name.startswith("lid-mapping-") for name in payload["files"])
+    assert any(name.startswith("device-index-") for name in payload["files"])
+    assert any(name.startswith("device-list-") for name in payload["files"])


### PR DESCRIPTION
## Summary
- convert the runtime to native ES modules and upgrade Baileys to v7.0.0-rc.8
- add LID-aware JID normalization/migration helpers so existing channel mappings and whitelists keep working
- update the Discord/WhatsApp handlers and supporting utilities to use the new Baileys APIs and migrate legacy data

**Extremely unstable backup storage before testing**