### PR TITLE
Workaround for lists and contact name and name detection in general

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1422,7 +1422,11 @@ const whatsapp = {
   updateContacts(rawContacts) {
     const contacts = rawContacts.chats || rawContacts.contacts || rawContacts;
     for (const contact of contacts) {
-      const name = contact?.name || contact?.subject;
+      const name = contact?.name
+        || contact?.subject
+        || contact?.verifiedName
+        || contact?.notify
+        || contact?.pushName;
       if (!name) continue;
       const preferredId = this.formatJid(contact?.id);
       let alternateId = null;


### PR DESCRIPTION
What changed:
- The code that determines a contact's display name was expanded.
- Old logic:
  - name = `contact?.name || contact?.subject`
- New logic:
  - name = `contact?.name || contact?.subject || contact?.verifiedName || contact?.notify || contact?.pushName`

intent:
- Improve robustness of contact name detection by falling back to additional fields (`verifiedName`, `notify`, `pushName`) when `name` or `subject` are missing.