### PR TITLE
List command possible fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 storage/
 out.js
 .env
+.DS_Store

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -827,19 +827,27 @@ const commands = {
     await controlChannel.send('See all the available commands at https://arespawn.github.io/WhatsAppToDiscord/#/commands');
   },
   async resync(_message, params) {
-    await state.waClient.authState.keys.set({
-      'app-state-sync-version': { critical_unblock_low: null },
-    });
-    await state.waClient.resyncAppState(['critical_unblock_low']);
-    for (const [jid, attributes] of Object.entries(await state.waClient.groupFetchAllParticipating())) { state.waClient.contacts[jid] = attributes.subject; }
-    if (params.includes('rename')) {
-      try {
-        await utils.discord.renameChannels();
-      } catch (err) {
-        state.logger?.error(err);
+    const hard = params.includes('hard') || params.includes('reset');
+    try {
+      const { clearedKeys } = await utils.whatsapp.resetAppStateSync(hard);
+      for (const [jid, attributes] of Object.entries(await state.waClient.groupFetchAllParticipating())) {
+        state.waClient.contacts[jid] = attributes.subject;
       }
+      if (params.includes('rename')) {
+        try {
+          await utils.discord.renameChannels();
+        } catch (err) {
+          state.logger?.error(err);
+        }
+      }
+      const suffix = hard
+        ? ` (cleared ${clearedKeys} app state key${clearedKeys === 1 ? '' : 's'} and requested fresh keys)`
+        : '';
+      await controlChannel.send(`Re-synced${suffix}!`);
+    } catch (err) {
+      state.logger?.error(err);
+      await controlChannel.send('Re-sync failed, check logs for details.');
     }
-    await controlChannel.send('Re-synced!');
   },
   async enablelocaldownloads() {
     state.settings.LocalDownloads = true;


### PR DESCRIPTION
Added a hard resync path that clears potentially corrupted app-state keys and asks WhatsApp for fresh keys to address the bad decrypt during critical_unblock_low sync.

- src/utils.js: added _listAppStateKeyIds and resetAppStateSync(hard) to reset all app-state versions, optionally drop stored app-state sync keys, flush the key cache, send an APP_STATE_SYNC_KEY_REQUEST, and then rerun a full app-state resync.

- src/discordHandler.js: resync now uses the helper, accepts resync hard to trigger the key purge/request flow, refreshes group subjects, and keeps the rename option with clearer status messaging.