### PR TITLE
Introduce slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Di
 
 Originally created by [Fatih Kilic](https://github.com/FKLC), the project is now maintained by [arespawn](https://github.com/arespawn) with the blessing of the previous author.
 
-> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.4` ships the Baileys 7 migration and is considered **unstable**. Expect rapid changes and breaking issues until a stable tag is published.
+> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.5` ships the Baileys 7 migration and is considered **unstable**. Expect rapid changes and breaking issues until a stable tag is published.
 
 ## Requirements
 
@@ -62,7 +62,7 @@ This keeps you in control of when updates are applied instead of auto-updating.
 ### Automatic updates
 
 Images are published to the GitHub Container Registry on every release, with
-immutable version tags (for example, `v2.0.0-alpha.4`) and moving channels:
+immutable version tags (for example, `v2.0.0-alpha.5`) and moving channels:
 
 - `stable` (also published as `latest`) tracks the newest stable release.
 - `unstable` tracks the newest prerelease.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Di
 
 Originally created by [Fatih Kilic](https://github.com/FKLC), now maintained by [arespawn](https://github.com/arespawn).
 
-> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.4` introduces the Baileys 7 migration and is **not yet stable**. Expect rapid updates and potential breaking changes until a stable release lands.
+> ⚠️ **Alpha release notice:** Version `v2.0.0-alpha.5` introduces the Baileys 7 migration and is **not yet stable**. Expect rapid updates and potential breaking changes until a stable release lands.
 
 ## Requirements
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,5 @@
 # Commands
-You can use the following commands only in `#control-room` created by the bot. Note that all the commands are case-insensitive. So, `list`, `LIST`, and `lIsT` would evaluate the same way.
+All commands are now available as slash commands anywhere in your server. Responses are ephemeral outside `#control-room`, but they post publicly when used inside the control room. Legacy text commands in `#control-room` still work for compatibility. Use Discord integration permissions to manage who can run these commands.
 
 ## pairWithCode
 Pairing with your phone number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "2.0.0-alpha.4",
+      "version": "2.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ if (!globalThis.crypto) {
 }
 
 (async () => {
-    const version = 'v2.0.0-alpha.4';
+    const version = 'v2.0.0-alpha.5';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/src/storage.js
+++ b/src/storage.js
@@ -92,7 +92,9 @@ const setup = {
     return new Promise((resolve) => {
       const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
       client.once('ready', () => {
-        state.logger?.info(`Invite the bot using the following link: https://discordapp.com/oauth2/authorize?client_id=${client.user.id}&scope=bot&permissions=536879120`);
+        state.logger?.info(
+          `Invite the bot using the following link: https://discordapp.com/oauth2/authorize?client_id=${client.user.id}&scope=bot%20application.commands&permissions=536879120`,
+        );
       });
       client.once('guildCreate', async (guild) => {
         const category = await guild.channels.create('whatsapp', {


### PR DESCRIPTION
- Added shared command context/responder helpers, full slash-command definitions, guild registration on ready, and interaction handling with auto-defer and control-room-aware ephemeral replies; message commands are routed through the same handlers

- Preserved all control actions (link/move/whitelist/update/etc.) as slash commands usable anywhere, with integration permissions managing access and explicit feedback for each action

- Documented the new slash-command availability, ephemeral behavior, and integration-permission management

- Bot needs new permission updated setup invite link and added safety net to check for command and send new invite link for reinvite