### PR TITLE
Prefer PN JIDs for 1:1 WhatsApp sends (fallback to LID)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wa2dc",
-  "version": "2.0.1-beta.5",
+  "version": "2.0.1-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wa2dc",
-      "version": "2.0.1-beta.5",
+      "version": "2.0.1-beta.6",
       "license": "MIT",
       "dependencies": {
         "@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wa2dc",
-  "version": "2.0.1-beta.5",
+  "version": "2.0.1-beta.6",
   "description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
   "type": "module",
   "main": "src/runner.js",

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1820,6 +1820,11 @@ client.on('messageCreate', async (message) => {
     return;
   }
 
+  const messageType = typeof message.type === 'number' ? Constants.MessageTypes?.[message.type] : message.type;
+  if (messageType === 'CHANNEL_PINNED_MESSAGE') {
+    return;
+  }
+
   if (message.channel.id === state.settings.ControlChannelID) {
     await message.channel.send('Regular commands have been removed. Please use Discord slash commands (/) instead.');
     return;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ if (!globalThis.crypto) {
 }
 
 (async () => {
-    const version = 'v2.0.1-beta.5';
+    const version = 'v2.0.1-beta.6';
   state.version = version;
   const streams = [
     { stream: pino.destination('logs.txt') },

--- a/tests/jidPreference.test.js
+++ b/tests/jidPreference.test.js
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+import { resetClientFactoryOverrides, setClientFactoryOverrides } from '../src/clientFactories.js';
+import state from '../src/state.js';
+import utils from '../src/utils.js';
+
+const snapshotObject = (value) => ({ ...value });
+const restoreObject = (target, snapshot) => {
+  Object.keys(target).forEach((key) => { delete target[key]; });
+  Object.assign(target, snapshot);
+};
+
+const snapshotWhitelist = () => Array.isArray(state.settings.Whitelist) ? [...state.settings.Whitelist] : [];
+
+test('hydrateJidPair prefers PN and migrates LID chat keys', async () => {
+  const originalWaClient = state.waClient;
+  const originalLogger = state.logger;
+  const originalChats = snapshotObject(state.chats);
+  const originalContacts = snapshotObject(state.contacts);
+  const originalWhitelist = snapshotWhitelist();
+
+  try {
+    state.logger = { warn() {} };
+    restoreObject(state.chats, {});
+    restoreObject(state.contacts, {});
+    state.settings.Whitelist = [];
+
+    const lidJid = '161040050426060@lid';
+    const pnJid = '14155550123@s.whatsapp.net';
+
+    state.chats[lidJid] = { channelId: 'chan-1' };
+    state.contacts[lidJid] = 'Alice';
+
+    state.waClient = {
+      signalRepository: {
+        lidMapping: {
+          getPNForLID: async (lid) => (utils.whatsapp.formatJid(lid) === lidJid ? pnJid : null),
+          getLIDForPN: async (pn) => (utils.whatsapp.formatJid(pn) === pnJid ? lidJid : null),
+        },
+      },
+      contacts: {},
+    };
+
+    const [preferred, fallback] = await utils.whatsapp.hydrateJidPair(lidJid);
+
+    assert.equal(preferred, pnJid);
+    assert.equal(fallback, lidJid);
+    assert.equal(state.chats[lidJid], undefined);
+    assert.equal(state.chats[pnJid]?.channelId, 'chan-1');
+  } finally {
+    state.waClient = originalWaClient;
+    state.logger = originalLogger;
+    restoreObject(state.chats, originalChats);
+    restoreObject(state.contacts, originalContacts);
+    state.settings.Whitelist = originalWhitelist;
+  }
+});
+
+test('hydrateJidPair keeps PN preferred when a LID mapping exists', async () => {
+  const originalWaClient = state.waClient;
+  const originalLogger = state.logger;
+  const originalChats = snapshotObject(state.chats);
+  const originalContacts = snapshotObject(state.contacts);
+  const originalWhitelist = snapshotWhitelist();
+
+  try {
+    state.logger = { warn() {} };
+    restoreObject(state.chats, {});
+    restoreObject(state.contacts, {});
+    state.settings.Whitelist = [];
+
+    const lidJid = '161040050426060@lid';
+    const pnJid = '14155550123@s.whatsapp.net';
+
+    state.chats[pnJid] = { channelId: 'chan-pn' };
+    state.chats[lidJid] = { channelId: 'chan-lid' };
+
+    state.waClient = {
+      signalRepository: {
+        lidMapping: {
+          getPNForLID: async (lid) => (utils.whatsapp.formatJid(lid) === lidJid ? pnJid : null),
+          getLIDForPN: async (pn) => (utils.whatsapp.formatJid(pn) === pnJid ? lidJid : null),
+        },
+      },
+      contacts: {},
+    };
+
+    const [preferred, fallback] = await utils.whatsapp.hydrateJidPair(pnJid);
+
+    assert.equal(preferred, pnJid);
+    assert.equal(fallback, lidJid);
+    assert.equal(state.chats[pnJid]?.channelId, 'chan-pn');
+    assert.equal(state.chats[lidJid], undefined);
+  } finally {
+    state.waClient = originalWaClient;
+    state.logger = originalLogger;
+    restoreObject(state.chats, originalChats);
+    restoreObject(state.contacts, originalContacts);
+    state.settings.Whitelist = originalWhitelist;
+  }
+});
+
+test('WhatsApp sendMessage wrapper prefers PN when available', async () => {
+  const originalWaClient = state.waClient;
+  const originalLogger = state.logger;
+  const originalChats = snapshotObject(state.chats);
+  const originalContacts = snapshotObject(state.contacts);
+  const originalWhitelist = snapshotWhitelist();
+  const originalGetControlChannel = utils.discord.getControlChannel;
+
+  try {
+    state.logger = { info() {}, warn() {}, error() {}, debug() {} };
+    restoreObject(state.chats, {});
+    restoreObject(state.contacts, {});
+    state.settings.Whitelist = [];
+    utils.discord.getControlChannel = async () => ({ send: async () => {} });
+
+    const lidJid = '161040050426060@lid';
+    const pnJid = '14155550123@s.whatsapp.net';
+
+    class FakeWhatsAppClient {
+      constructor() {
+        this.ev = new EventEmitter();
+        this.ws = { on() {} };
+        this.user = { id: '0@s.whatsapp.net' };
+        this.contacts = {};
+        this.signalRepository = {
+          lidMapping: {
+            getPNForLID: async (lid) => (utils.whatsapp.formatJid(lid) === lidJid ? pnJid : null),
+          },
+        };
+        this.sendCalls = [];
+      }
+
+      async sendMessage(jid, content, options) {
+        this.sendCalls.push({ jid, content, options });
+        return { key: { id: 'sent-1', remoteJid: jid } };
+      }
+
+      async groupFetchAllParticipating() {
+        return {};
+      }
+
+      async profilePictureUrl() {
+        return null;
+      }
+    }
+
+    const fakeClient = new FakeWhatsAppClient();
+    setClientFactoryOverrides({
+      createWhatsAppClient: () => fakeClient,
+      getBaileysVersion: async () => ({ version: [1, 0, 0] }),
+    });
+
+    const { connectToWhatsApp } = await import('../src/whatsappHandler.js');
+    await connectToWhatsApp();
+    state.waClient = fakeClient;
+
+    await fakeClient.sendMessage(lidJid, { text: 'hi', linkPreview: {} }, {});
+
+    assert.equal(fakeClient.sendCalls[0]?.jid, pnJid);
+  } finally {
+    utils.discord.getControlChannel = originalGetControlChannel;
+    resetClientFactoryOverrides();
+    state.waClient = originalWaClient;
+    state.logger = originalLogger;
+    restoreObject(state.chats, originalChats);
+    restoreObject(state.contacts, originalContacts);
+    state.settings.Whitelist = originalWhitelist;
+  }
+});
+


### PR DESCRIPTION
Baileys guidance is to always reply to PN for 1:1 when available to avoid duplicate chats and improve consistency.

- 1:1 addressing now uses PN when known; falls back to LID only if PN isn’t available.
- Group behavior is unchanged.
- Pin small bug fix
- bump to beta.6

I am holding the 2.0.1 release as it seems baileys is getting closer to a true 7.0.0 release