### PR TITLE
Add redirectBots toggle to control Discord bot message mirroring

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,6 +135,10 @@ Toggle profile-picture / status-change alerts.
 Restrict the bridge to one direction or keep it bidirectional.  
 Usage: `/oneway direction:<discord|whatsapp|disabled>`
 
+### `/redirectbots`
+Allow or block Discord bot messages from being forwarded to WhatsApp.  
+Usage: `/redirectbots enabled:<true|false>`
+
 ### `/redirectwebhooks`
 Allow or block Discord webhook messages from being forwarded to WhatsApp.  
 Usage: `/redirectwebhooks enabled:<true|false>`

--- a/src/state.js
+++ b/src/state.js
@@ -25,6 +25,7 @@ const state = {
     autoSaveInterval: 5 * 60,
     lastMessageStorage: 500,
     oneWay: 0b11,
+    redirectBots: true,
     redirectWebhooks: false,
     DeleteMessages: true,
     ReadReceipts: true,


### PR DESCRIPTION
This pr adds a `redirectBots` toggle (default `true`) to control whether Discord bot messages are mirrored to WhatsApp. Introduces `/redirectbots enabled:<true|false>` command to disable or re-enable bot forwarding. Applies the toggle across Discord message create/update/delete/reaction handlers and suppresses edit/delete/reaction warnings for ignored bot messages. Includes documentation and test coverage.

Thanks [AriKnight](https://github.com/AriKnight) for the idea via #145 