### PR TITLE
Implement recoverable unhandled rejection handling with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/runner.js",
     "docs": "docsify serve docs",
-    "bundle": "esbuild src/runner.js --bundle --platform=node --format=cjs --external:sharp --external:qrcode-terminal --external:jimp --external:link-preview-js --target=node24 --outfile=out.cjs",
+    "bundle": "esbuild src/runner.js --bundle --platform=node --format=cjs --external:sharp --external:qrcode-terminal --external:link-preview-js --target=node24 --outfile=out.cjs",
     "build:bin": "node scripts/buildBinary.js",
     "build:bin:smoke": "node scripts/buildBinary.js --smoke",
     "test": "node --test",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import state from './state.js';
 import utils from './utils.js';
 import storage from './storage.js';
 import whatsappHandler from './whatsappHandler.js';
+import { isRecoverableUnhandledRejection } from './processErrors.js';
 
 const isSmokeTest = process.env.WA2DC_SMOKE_TEST === '1';
 
@@ -24,10 +25,21 @@ if (!globalThis.crypto) {
   ];
   state.logger = pino({ mixin() { return { version }; } }, pino.multistream(streams));
   let autoSaver = setInterval(() => storage.save(), 5 * 60 * 1000);
+  let shuttingDown = false;
   ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].forEach((eventName) => {
     process.on(eventName, async (err) => {
+      if (eventName === 'unhandledRejection' && isRecoverableUnhandledRejection(err)) {
+        state.logger.warn({ err }, 'Ignoring recoverable network rejection');
+        return;
+      }
+      if (shuttingDown) {
+        return;
+      }
+      shuttingDown = true;
       clearInterval(autoSaver);
-      state.logger.error(err);
+      if (err != null) {
+        state.logger.error(err);
+      }
       state.logger.info('Exiting!');
       let logs = '';
       try {

--- a/src/processErrors.js
+++ b/src/processErrors.js
@@ -1,0 +1,70 @@
+const MAX_ERROR_CAUSE_DEPTH = 6;
+const RECOVERABLE_NETWORK_MESSAGE_HINTS = [
+  'terminated',
+  'fetch failed',
+  'other side closed',
+  'socket',
+  'tls',
+  'ssl',
+  'timed out',
+  'timeout',
+  'econnreset',
+  'enotfound',
+  'ehostunreach',
+  'eai_again',
+  'certificate',
+];
+const RECOVERABLE_NETWORK_CODE_HINTS = [
+  'UND_ERR',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'EHOSTUNREACH',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'CERT_',
+];
+
+const asLower = (value) => String(value || '').toLowerCase();
+
+const collectErrorChain = (reason) => {
+  const chain = [];
+  let current = reason;
+  for (let i = 0; i < MAX_ERROR_CAUSE_DEPTH && current; i += 1) {
+    if (chain.includes(current)) {
+      break;
+    }
+    chain.push(current);
+    current = current?.cause;
+  }
+  return chain;
+};
+
+const includesHint = (text, hints) => hints.some((hint) => text.includes(asLower(hint)));
+
+export const isRecoverableUnhandledRejection = (reason) => {
+  const chain = collectErrorChain(reason);
+  if (!chain.length) {
+    return false;
+  }
+
+  const messageText = asLower(chain.map((entry) => entry?.message || entry).join(' | '));
+  const codeText = asLower(chain.map((entry) => entry?.code || '').join(' | '));
+  const stackText = asLower(chain.map((entry) => entry?.stack || '').join('\n'));
+
+  const looksLikeUndici = (
+    stackText.includes('node:internal/deps/undici/undici')
+    || stackText.includes('/undici/')
+    || codeText.includes('und_err')
+    || messageText.includes('fetch failed')
+    || messageText.includes('terminated')
+  );
+  if (!looksLikeUndici) {
+    return false;
+  }
+
+  return (
+    includesHint(messageText, RECOVERABLE_NETWORK_MESSAGE_HINTS)
+    || includesHint(codeText, RECOVERABLE_NETWORK_CODE_HINTS)
+  );
+};
+

--- a/tests/processErrors.test.js
+++ b/tests/processErrors.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isRecoverableUnhandledRejection } from '../src/processErrors.js';
+
+test('classifies undici terminated socket close as recoverable', () => {
+  const socketError = new Error('other side closed');
+  socketError.code = 'UND_ERR_SOCKET';
+
+  const reason = new TypeError('terminated');
+  reason.cause = socketError;
+  reason.stack = 'TypeError: terminated\n    at Fetch.onAborted (node:internal/deps/undici/undici:12707:53)';
+
+  assert.equal(isRecoverableUnhandledRejection(reason), true);
+});
+
+test('classifies undici TLS fetch failures as recoverable', () => {
+  const tlsError = new Error('tlsv1 alert internal error');
+  tlsError.code = 'ECONNRESET';
+
+  const reason = new TypeError('fetch failed');
+  reason.cause = tlsError;
+  reason.stack = 'TypeError: fetch failed\n    at node:internal/deps/undici/undici:16416:13';
+
+  assert.equal(isRecoverableUnhandledRejection(reason), true);
+});
+
+test('does not classify generic coding errors as recoverable', () => {
+  const reason = new TypeError("Cannot read properties of undefined (reading 'x')");
+  reason.stack = 'TypeError: Cannot read properties of undefined (reading \'x\')\n    at file:///app/src/handler.js:10:5';
+
+  assert.equal(isRecoverableUnhandledRejection(reason), false);
+});
+


### PR DESCRIPTION
Introduce handling for recoverable unhandled rejections, allowing the application to ignore specific network-related errors. Add tests to verify the functionality of the new error classification.