### PR TITLE
Add WhatsApp-compatible waveform metadata for Discord voice messages

### DIFF
--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -32,6 +32,7 @@ Respect transport constraints when emitting output:
 - 2000-character message limit
 - use `utils.discord.partitionText(...)` for long responses
 - respect file-size gating (for example `DiscordFileSizeLimit`)
+- voice-note (`ptt`) sends from Discord should keep WhatsApp compatibility metadata intact (`audio/ogg; codecs=opus` when transcoded, `ptt: true`, and waveform bytes when available)
 
 ## Routing gates
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ WA2DC can mirror Discord voice-style attachments to WhatsApp voice notes (`ptt`)
 
 - For best compatibility, install `ffmpeg` on the host running WA2DC. The bridge will transcode Discord voice uploads to Opus/Ogg mono before sending.
 - If `ffmpeg` is not installed, WA2DC still attempts a raw audio send, but some voice uploads may fail on WhatsApp clients.
-- `audio-decode` remains optional and is only needed for waveform generation.
+- WA2DC also attempts to generate WhatsApp-compatible waveform metadata automatically. If decoding fails, the voice note still sends, but WhatsApp may not show waveform bars.
 
 ## Can I bridge WhatsApp calls to Discord?
 No. The WhatsApp Web protocol used by the bot does not expose the real-time audio or video streams of a call. Incoming and missed calls are only sent as notifications to Discord, so the bot cannot relay or receive live WhatsApp calls.

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -8,6 +8,7 @@ import {
 	WAMessageStubType,
 } from "@whiskeysockets/baileys";
 import { getKeyAuthor } from "@whiskeysockets/baileys/lib/Utils/generics.js";
+import { getAudioWaveform } from "@whiskeysockets/baileys/lib/Utils/messages-media.js";
 import { decryptPollVote } from "@whiskeysockets/baileys/lib/Utils/process-message.js";
 import useSQLiteAuthState from "./auth/sqliteAuthState.js";
 import { createWhatsAppClient, getBaileysVersion } from "./clientFactories.js";
@@ -749,6 +750,23 @@ const transcodeAudioBufferToOggOpus = async (inputBuffer) => {
 	});
 };
 
+const generateAudioWaveformForWhatsApp = async (audio) => {
+	const audioBuffer = toBuffer(audio);
+	if (!audioBuffer?.length) return null;
+	try {
+		const waveform = await getAudioWaveform(audioBuffer, state.logger);
+		const waveformBuffer = toBuffer(waveform);
+		if (!waveformBuffer?.length) return null;
+		return waveformBuffer;
+	} catch (err) {
+		state.logger?.debug?.(
+			{ err },
+			"Failed to generate WhatsApp-compatible waveform for Discord voice message",
+		);
+		return null;
+	}
+};
+
 const normalizeAudioSendContentForWhatsApp = async ({
 	attachment,
 	content,
@@ -829,6 +847,18 @@ const normalizeAudioSendContentForWhatsApp = async ({
 				},
 				"Failed to transcode Discord voice message to WhatsApp-compatible opus",
 			);
+		}
+	}
+
+	const waveformCandidates = [normalizedContent.audio];
+	if (sourceBuffer?.length && normalizedContent.audio !== sourceBuffer) {
+		waveformCandidates.push(sourceBuffer);
+	}
+	for (const candidate of waveformCandidates) {
+		const generatedWaveform = await generateAudioWaveformForWhatsApp(candidate);
+		if (generatedWaveform?.length) {
+			normalizedContent.waveform = generatedWaveform;
+			break;
 		}
 	}
 

--- a/tests/whatsappBridge.test.js
+++ b/tests/whatsappBridge.test.js
@@ -31,6 +31,38 @@ const restoreSet = (target, snapshot) => {
 	});
 };
 
+const createMonoPcmWavBuffer = ({
+	sampleRate = 16_000,
+	durationSeconds = 1,
+	frequencyHz = 440,
+	amplitude = 0.4,
+} = {}) => {
+	const totalSamples = Math.max(1, Math.floor(sampleRate * durationSeconds));
+	const dataSize = totalSamples * 2;
+	const buffer = Buffer.alloc(44 + dataSize);
+	buffer.write("RIFF", 0, "ascii");
+	buffer.writeUInt32LE(36 + dataSize, 4);
+	buffer.write("WAVE", 8, "ascii");
+	buffer.write("fmt ", 12, "ascii");
+	buffer.writeUInt32LE(16, 16);
+	buffer.writeUInt16LE(1, 20);
+	buffer.writeUInt16LE(1, 22);
+	buffer.writeUInt32LE(sampleRate, 24);
+	buffer.writeUInt32LE(sampleRate * 2, 28);
+	buffer.writeUInt16LE(2, 32);
+	buffer.writeUInt16LE(16, 34);
+	buffer.write("data", 36, "ascii");
+	buffer.writeUInt32LE(dataSize, 40);
+
+	for (let idx = 0; idx < totalSamples; idx += 1) {
+		const sample =
+			Math.sin((2 * Math.PI * frequencyHz * idx) / sampleRate) * amplitude;
+		const normalized = Math.max(-1, Math.min(1, sample));
+		buffer.writeInt16LE(Math.round(normalized * 32767), 44 + idx * 2);
+	}
+	return buffer;
+};
+
 const setupWhatsAppHarness = async ({
 	oneWay = 0b11,
 	inWhitelist = () => true,
@@ -1517,6 +1549,64 @@ test("Discord voice-style audio attachments are sent as WhatsApp ptt messages", 
 		assert.ok(Buffer.isBuffer(sentContent.audio));
 		assert.ok(Buffer.isBuffer(sentContent.waveform));
 		assert.ok(String(sentContent.mimetype || "").startsWith("audio/ogg"));
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("Discord voice-style audio attachments generate WhatsApp waveform metadata", async () => {
+	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
+	try {
+		utils.whatsapp.createDocumentContent = (attachment) => ({
+			audio: { url: attachment.url },
+			mimetype: attachment.contentType,
+		});
+
+		const wavBytes = createMonoPcmWavBuffer({
+			sampleRate: 16_000,
+			durationSeconds: 1,
+			frequencyHz: 523,
+		});
+		const attachmentUrl = `data:audio/wav;base64,${wavBytes.toString("base64")}`;
+
+		harness.fakeClient.ev.emit("discordMessage", {
+			jid: "120363123456789@s.whatsapp.net",
+			forwardContext: null,
+			message: {
+				id: "dc-voice-waveform-generated",
+				content: "",
+				cleanContent: "",
+				webhookId: null,
+				author: { username: "BridgeUser" },
+				member: { displayName: "BridgeUser" },
+				channel: { send: async () => {} },
+				attachments: new Map([
+					[
+						"attachment-1",
+						{
+							id: "attachment-1",
+							url: attachmentUrl,
+							name: "voice-message.wav",
+							contentType: "audio/wav",
+							duration: 1,
+						},
+					],
+				]),
+				stickers: new Map(),
+				embeds: [],
+				mentions: { users: new Map(), members: new Map(), roles: new Map() },
+			},
+		});
+
+		await delay(120);
+
+		assert.equal(harness.fakeClient.sendCalls.length, 1);
+		const sentContent = harness.fakeClient.sendCalls[0]?.content || {};
+		assert.equal(sentContent.ptt, true);
+		assert.equal(sentContent.seconds, 1);
+		assert.ok(Buffer.isBuffer(sentContent.waveform));
+		assert.equal(sentContent.waveform.length, 64);
+		assert.ok(sentContent.waveform.every((entry) => entry >= 0 && entry <= 100));
 	} finally {
 		harness.cleanup();
 	}


### PR DESCRIPTION
Introduce functionality to generate and send WhatsApp-compatible waveform metadata for voice messages sent from Discord, ensuring compatibility with WhatsApp's audio format requirements.