### PR TITLE
Drop Jimp dependency and update version

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ WA2DC can mirror Discord voice-style attachments to WhatsApp voice notes (`ptt`)
 - If `ffmpeg` is not installed, WA2DC still attempts a raw audio send, but some voice uploads may fail on WhatsApp clients.
 
 ## Why did a Discord image arrive on WhatsApp as a file?
-WA2DC now normalizes static unsupported Discord image formats such as pasted WebP before sending them to WhatsApp. If the image cannot be decoded safely, the bridge falls back to sending it as a regular document so the message is still delivered instead of being dropped.
+WA2DC now normalizes static unsupported Discord image formats such as pasted WebP before sending them to WhatsApp. This normalization relies on `sharp`. If `sharp` is unavailable in the current runtime or the image still cannot be decoded safely, the bridge falls back to sending it as a regular document so the message is still delivered instead of being dropped.
 
 GIF uploads prefer Discord's animated video rendition when Discord exposes both a file entry and a preview embed for the same media, so the same GIF should not be mirrored twice.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,21 +11,20 @@
 			"dependencies": {
 				"@adiwajshing/keyed-db": "^0.2.4",
 				"@whiskeysockets/baileys": "^7.0.0-rc.9",
-				"canvas": "^3.2.1",
+				"canvas": "^3.2.2",
 				"discord.js": "^14.25.1",
-				"jimp": "^1.6.0",
-				"jsdom": "^29.0.0",
+				"jsdom": "^29.0.1",
 				"link-preview-js": "3.2.0",
 				"lottie-web": "^5.13.0",
 				"pino": "^10.3.1",
 				"pino-pretty": "^13.1.2",
 				"qrcode": "^1.5.3",
 				"sharp": "^0.34.5",
-				"tar": "^7.5.11",
-				"undici": "^7.24.4"
+				"tar": "^7.5.13",
+				"undici": "^7.24.6"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.7",
+				"@biomejs/biome": "^2.4.9",
 				"esbuild": "^0.27.4"
 			},
 			"engines": {
@@ -76,9 +75,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
-			"integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+			"integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -92,20 +91,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.7",
-				"@biomejs/cli-darwin-x64": "2.4.7",
-				"@biomejs/cli-linux-arm64": "2.4.7",
-				"@biomejs/cli-linux-arm64-musl": "2.4.7",
-				"@biomejs/cli-linux-x64": "2.4.7",
-				"@biomejs/cli-linux-x64-musl": "2.4.7",
-				"@biomejs/cli-win32-arm64": "2.4.7",
-				"@biomejs/cli-win32-x64": "2.4.7"
+				"@biomejs/cli-darwin-arm64": "2.4.9",
+				"@biomejs/cli-darwin-x64": "2.4.9",
+				"@biomejs/cli-linux-arm64": "2.4.9",
+				"@biomejs/cli-linux-arm64-musl": "2.4.9",
+				"@biomejs/cli-linux-x64": "2.4.9",
+				"@biomejs/cli-linux-x64-musl": "2.4.9",
+				"@biomejs/cli-win32-arm64": "2.4.9",
+				"@biomejs/cli-win32-x64": "2.4.9"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
-			"integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+			"integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
 			"cpu": [
 				"arm64"
 			],
@@ -120,9 +119,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
-			"integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+			"integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
 			"cpu": [
 				"x64"
 			],
@@ -137,9 +136,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
-			"integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+			"integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
 			"cpu": [
 				"arm64"
 			],
@@ -154,9 +153,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
-			"integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+			"integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
 			"cpu": [
 				"arm64"
 			],
@@ -171,9 +170,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
-			"integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+			"integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -188,9 +187,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
-			"integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+			"integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
 			"cpu": [
 				"x64"
 			],
@@ -205,9 +204,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
-			"integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+			"integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -222,9 +221,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.7",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
-			"integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+			"integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
 			"cpu": [
 				"x64"
 			],
@@ -1512,490 +1511,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@jimp/core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
-			"integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/file-ops": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"await-to-js": "^3.0.0",
-				"exif-parser": "^0.1.12",
-				"file-type": "^16.0.0",
-				"mime": "3"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/core/node_modules/file-type": {
-			"version": "16.5.4",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-			"integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-			"license": "MIT",
-			"dependencies": {
-				"readable-web-to-node-stream": "^3.0.0",
-				"strtok3": "^6.2.4",
-				"token-types": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/@jimp/core/node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@jimp/core/node_modules/strtok3": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-			"integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"peek-readable": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@jimp/core/node_modules/token-types": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-			"integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@jimp/diff": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
-			"integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"pixelmatch": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/file-ops": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
-			"integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/js-bmp": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
-			"integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"bmp-ts": "^1.0.9"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/js-gif": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
-			"integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"gifwrap": "^0.10.1",
-				"omggif": "^1.0.10"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/js-jpeg": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
-			"integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"jpeg-js": "^0.4.4"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/js-png": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
-			"integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"pngjs": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/js-png/node_modules/pngjs": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.19.0"
-			}
-		},
-		"node_modules/@jimp/js-tiff": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
-			"integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"utif2": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-blit": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
-			"integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-blur": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
-			"integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/utils": "1.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-circle": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
-			"integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-color": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
-			"integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"tinycolor2": "^1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-contain": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
-			"integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/plugin-blit": "1.6.0",
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-cover": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
-			"integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/plugin-crop": "1.6.0",
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-crop": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
-			"integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-displace": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
-			"integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-dither": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
-			"integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-fisheye": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
-			"integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-flip": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
-			"integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-hash": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
-			"integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/js-bmp": "1.6.0",
-				"@jimp/js-jpeg": "1.6.0",
-				"@jimp/js-png": "1.6.0",
-				"@jimp/js-tiff": "1.6.0",
-				"@jimp/plugin-color": "1.6.0",
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"any-base": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-mask": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
-			"integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-print": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
-			"integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/js-jpeg": "1.6.0",
-				"@jimp/js-png": "1.6.0",
-				"@jimp/plugin-blit": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"parse-bmfont-ascii": "^1.0.6",
-				"parse-bmfont-binary": "^1.0.6",
-				"parse-bmfont-xml": "^1.1.6",
-				"simple-xml-to-json": "^1.2.2",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-quantize": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
-			"integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
-			"license": "MIT",
-			"dependencies": {
-				"image-q": "^4.0.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-resize": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
-			"integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-rotate": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
-			"integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/plugin-crop": "1.6.0",
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/plugin-threshold": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
-			"integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/plugin-color": "1.6.0",
-				"@jimp/plugin-hash": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0",
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/types": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
-			"integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
-			"license": "MIT",
-			"dependencies": {
-				"zod": "^3.23.8"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@jimp/utils": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
-			"integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/types": "1.6.0",
-				"tinycolor2": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
@@ -2230,17 +1745,6 @@
 				"real-require": "^0.2.0"
 			}
 		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2248,12 +1752,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/any-base": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-			"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-			"license": "MIT"
 		},
 		"node_modules/async-mutex": {
 			"version": "0.5.0",
@@ -2270,15 +1768,6 @@
 			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/await-to-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
-			"integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -2358,40 +1847,11 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/bmp-ts": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
-			"integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
-			"license": "MIT"
-		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"license": "ISC"
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
 		},
 		"node_modules/cacheable": {
 			"version": "1.10.3",
@@ -2421,9 +1881,9 @@
 			}
 		},
 		"node_modules/canvas": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.1.tgz",
-			"integrity": "sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.2.tgz",
+			"integrity": "sha512-duEt4h1HHu9sJZyVKfLRXR6tsKPY7cEELzxSRJkwddOXYvQT3P/+es98SV384JA0zMOZ5s+9gatnGfM6sL4Drg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2812,32 +2272,11 @@
 				"@esbuild/win32-x64": "0.27.4"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
 			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"license": "MIT"
-		},
-		"node_modules/events": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"engines": {
-				"node": ">=0.8.x"
-			}
-		},
-		"node_modules/exif-parser": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
 		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
@@ -2904,16 +2343,6 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/gifwrap": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
-			"integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
-			"license": "MIT",
-			"dependencies": {
-				"image-q": "^4.0.0",
-				"omggif": "^1.0.10"
 			}
 		},
 		"node_modules/github-from-package": {
@@ -2984,21 +2413,6 @@
 				}
 			]
 		},
-		"node_modules/image-q": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-			"integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "16.9.1"
-			}
-		},
-		"node_modules/image-q/node_modules/@types/node": {
-			"version": "16.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-			"license": "MIT"
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3025,44 +2439,6 @@
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"license": "MIT"
 		},
-		"node_modules/jimp": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
-			"integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
-			"license": "MIT",
-			"dependencies": {
-				"@jimp/core": "1.6.0",
-				"@jimp/diff": "1.6.0",
-				"@jimp/js-bmp": "1.6.0",
-				"@jimp/js-gif": "1.6.0",
-				"@jimp/js-jpeg": "1.6.0",
-				"@jimp/js-png": "1.6.0",
-				"@jimp/js-tiff": "1.6.0",
-				"@jimp/plugin-blit": "1.6.0",
-				"@jimp/plugin-blur": "1.6.0",
-				"@jimp/plugin-circle": "1.6.0",
-				"@jimp/plugin-color": "1.6.0",
-				"@jimp/plugin-contain": "1.6.0",
-				"@jimp/plugin-cover": "1.6.0",
-				"@jimp/plugin-crop": "1.6.0",
-				"@jimp/plugin-displace": "1.6.0",
-				"@jimp/plugin-dither": "1.6.0",
-				"@jimp/plugin-fisheye": "1.6.0",
-				"@jimp/plugin-flip": "1.6.0",
-				"@jimp/plugin-hash": "1.6.0",
-				"@jimp/plugin-mask": "1.6.0",
-				"@jimp/plugin-print": "1.6.0",
-				"@jimp/plugin-quantize": "1.6.0",
-				"@jimp/plugin-resize": "1.6.0",
-				"@jimp/plugin-rotate": "1.6.0",
-				"@jimp/plugin-threshold": "1.6.0",
-				"@jimp/types": "1.6.0",
-				"@jimp/utils": "1.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/joycon": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3072,20 +2448,14 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/jpeg-js": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/jsdom": {
-			"version": "29.0.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
-			"integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+			"version": "29.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+			"integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.0.1",
-				"@asamuzakjp/dom-selector": "^7.0.2",
+				"@asamuzakjp/dom-selector": "^7.0.3",
 				"@bramus/specificity": "^2.4.2",
 				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
 				"@exodus/bytes": "^1.15.0",
@@ -3099,7 +2469,7 @@
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
 				"tough-cookie": "^6.0.1",
-				"undici": "^7.24.3",
+				"undici": "^7.24.5",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^8.0.1",
 				"whatwg-mimetype": "^5.0.0",
@@ -3376,12 +2746,6 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/omggif": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-			"license": "MIT"
-		},
 		"node_modules/on-exit-leak-free": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -3434,34 +2798,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/pako": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"license": "(MIT AND Zlib)"
-		},
-		"node_modules/parse-bmfont-ascii": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-			"integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-			"license": "MIT"
-		},
-		"node_modules/parse-bmfont-binary": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-			"integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-			"license": "MIT"
-		},
-		"node_modules/parse-bmfont-xml": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
-			"integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
-			"license": "MIT",
-			"dependencies": {
-				"xml-parse-from-string": "^1.0.0",
-				"xml2js": "^0.5.0"
-			}
-		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3505,19 +2841,6 @@
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/peek-readable": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-			"integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/pino": {
@@ -3593,27 +2916,6 @@
 			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
 			"license": "MIT"
 		},
-		"node_modules/pixelmatch": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-			"integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
-			"license": "ISC",
-			"dependencies": {
-				"pngjs": "^6.0.0"
-			},
-			"bin": {
-				"pixelmatch": "bin/pixelmatch"
-			}
-		},
-		"node_modules/pixelmatch/node_modules/pngjs": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-			"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13.0"
-			}
-		},
 		"node_modules/pngjs": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
@@ -3647,14 +2949,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"engines": {
-				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/process-warning": {
@@ -3756,38 +3050,6 @@
 				"rc": "cli.js"
 			}
 		},
-		"node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/readable-web-to-node-stream": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-			"integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-			"license": "MIT",
-			"dependencies": {
-				"readable-stream": "^4.7.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/real-require": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -3844,12 +3106,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/sax": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
@@ -3985,15 +3241,6 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
-		"node_modules/simple-xml-to-json": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
-			"integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.12.2"
-			}
-		},
 		"node_modules/sonic-boom": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -4084,9 +3331,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tar": {
-			"version": "7.5.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+			"integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -4158,12 +3405,6 @@
 			"engines": {
 				"node": ">=20"
 			}
-		},
-		"node_modules/tinycolor2": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-			"integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-			"license": "MIT"
 		},
 		"node_modules/tldts": {
 			"version": "7.0.26",
@@ -4270,9 +3511,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-			"integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+			"integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -4291,15 +3532,6 @@
 			"dependencies": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			}
-		},
-		"node_modules/utif2": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
-			"integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
-			"license": "MIT",
-			"dependencies": {
-				"pako": "^1.0.11"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -4440,34 +3672,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/xml-parse-from-string": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-			"integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-			"license": "MIT"
-		},
-		"node_modules/xml2js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-			"license": "MIT",
-			"dependencies": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -4567,15 +3771,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wa2dc",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wa2dc",
-			"version": "2.3.0",
+			"version": "2.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -25,21 +25,20 @@
 	"dependencies": {
 		"@adiwajshing/keyed-db": "^0.2.4",
 		"@whiskeysockets/baileys": "^7.0.0-rc.9",
-		"canvas": "^3.2.1",
+		"canvas": "^3.2.2",
 		"discord.js": "^14.25.1",
-		"jimp": "^1.6.0",
-		"jsdom": "^29.0.0",
+		"jsdom": "^29.0.1",
 		"link-preview-js": "3.2.0",
 		"lottie-web": "^5.13.0",
 		"pino": "^10.3.1",
 		"pino-pretty": "^13.1.2",
 		"qrcode": "^1.5.3",
 		"sharp": "^0.34.5",
-		"tar": "^7.5.11",
-		"undici": "^7.24.4"
+		"tar": "^7.5.13",
+		"undici": "^7.24.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.7",
+		"@biomejs/biome": "^2.4.9",
 		"esbuild": "^0.27.4"
 	},
 	"pkg": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wa2dc",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
 	"type": "module",
 	"main": "src/runner.js",

--- a/src/imageLibs.js
+++ b/src/imageLibs.js
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 
-let imageJimpPromise = null;
 let imageSharpPromise = null;
 let packagedSharpRequire = null;
 let imageLibTestOverrides = null;
@@ -13,18 +12,6 @@ export const resetImageLibTestOverrides = () => {
 export const setImageLibTestOverrides = (overrides = null) => {
 	imageLibTestOverrides =
 		overrides && typeof overrides === "object" ? overrides : null;
-};
-
-export const getImageJimp = async () => {
-	if (typeof imageLibTestOverrides?.getImageJimp === "function") {
-		return imageLibTestOverrides.getImageJimp();
-	}
-	if (!imageJimpPromise) {
-		imageJimpPromise = import("jimp")
-			.then((mod) => (typeof mod?.Jimp?.read === "function" ? mod : null))
-			.catch(() => null);
-	}
-	return imageJimpPromise;
 };
 
 const getPackagedSharpRequire = () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ import * as linkPreview from "link-preview-js";
 import QRCode from "qrcode";
 import * as tar from "tar";
 import { Agent } from "undici";
-import { getImageJimp, getImageSharp } from "./imageLibs.js";
+import { getImageSharp } from "./imageLibs.js";
 import messageStore from "./messageStore.js";
 import state from "./state.js";
 import storage from "./storage.js";
@@ -1054,14 +1054,6 @@ const buildHighQualityThumbnail = async (
 					.resize({ width: 192, fit: "inside", withoutEnlargement: true })
 					.jpeg({ quality: 50 })
 					.toBuffer();
-			} else {
-				const jimp = await getImageJimp();
-				if (jimp) {
-					const img = await jimp.Jimp.read(buffer);
-					jpegThumbnail = await img
-						.resize({ w: 192, mode: jimp.ResizeStrategy.BILINEAR })
-						.getBuffer("image/jpeg", { quality: 50 });
-				}
 			}
 		} catch (err) {
 			state.logger?.debug?.(

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -17,7 +17,7 @@ import useSQLiteAuthState from "./auth/sqliteAuthState.js";
 import { createWhatsAppClient, getBaileysVersion } from "./clientFactories.js";
 import groupMetadataCache from "./groupMetadataCache.js";
 import { createGroupRefreshScheduler } from "./groupMetadataRefresh.js";
-import { getImageJimp, getImageSharp } from "./imageLibs.js";
+import { getImageSharp } from "./imageLibs.js";
 import { createAudioSendContentNormalizer } from "./internal/audioSendNormalization.js";
 import { createStickerSendContentNormalizer } from "./internal/stickerSendNormalization.js";
 import messageStore from "./messageStore.js";
@@ -783,34 +783,6 @@ const normalizeImageBufferWithSharp = async ({
 	};
 };
 
-const normalizeImageBufferWithJimp = async ({
-	sourceBuffer,
-	sourceMime,
-} = {}) => {
-	const jimp = await getImageJimp();
-	if (!jimp) {
-		return null;
-	}
-	const image = await jimp.Jimp.read(sourceBuffer);
-	const width = toIntegerOrNull(image?.bitmap?.width);
-	const height = toIntegerOrNull(image?.bitmap?.height);
-	const outboundMime = chooseNormalizedStaticImageMimeType({
-		sourceMime,
-	});
-	const outboundBuffer =
-		outboundMime === "image/jpeg"
-			? await image.getBuffer("image/jpeg", { quality: 82 })
-			: await image.getBuffer("image/png");
-	return {
-		decoder: "jimp",
-		animated: false,
-		outboundBuffer,
-		outboundMime,
-		width,
-		height,
-	};
-};
-
 const readImageDimensionsWithSharp = async ({ sourceBuffer } = {}) => {
 	const sharp = await getImageSharp();
 	if (!sharp) {
@@ -821,19 +793,6 @@ const readImageDimensionsWithSharp = async ({ sourceBuffer } = {}) => {
 		decoder: "sharp",
 		width: toIntegerOrNull(metadata?.width),
 		height: toIntegerOrNull(metadata?.height),
-	};
-};
-
-const readImageDimensionsWithJimp = async ({ sourceBuffer } = {}) => {
-	const jimp = await getImageJimp();
-	if (!jimp) {
-		return null;
-	}
-	const image = await jimp.Jimp.read(sourceBuffer);
-	return {
-		decoder: "jimp",
-		width: toIntegerOrNull(image?.bitmap?.width),
-		height: toIntegerOrNull(image?.bitmap?.height),
 	};
 };
 
@@ -859,27 +818,6 @@ const buildJpegThumbnailWithSharp = async ({ sourceBuffer } = {}) => {
 	};
 };
 
-const buildJpegThumbnailWithJimp = async ({ sourceBuffer } = {}) => {
-	const jimp = await getImageJimp();
-	if (!jimp) {
-		return null;
-	}
-	const image = await jimp.Jimp.read(sourceBuffer);
-	return {
-		decoder: "jimp",
-		jpegThumbnail: await image
-			.resize({
-				w: WHATSAPP_OUTBOUND_JPEG_THUMB_WIDTH,
-				mode: jimp.ResizeStrategy.BILINEAR,
-			})
-			.getBuffer("image/jpeg", {
-				quality: WHATSAPP_OUTBOUND_JPEG_THUMB_QUALITY,
-			}),
-		width: toIntegerOrNull(image?.bitmap?.width),
-		height: toIntegerOrNull(image?.bitmap?.height),
-	};
-};
-
 const ensureImageThumbForWhatsAppSend = async ({
 	content,
 	jid,
@@ -897,10 +835,7 @@ const ensureImageThumbForWhatsAppSend = async ({
 		if (!sourceBuffer?.length) {
 			return content;
 		}
-		for (const buildThumbnail of [
-			buildJpegThumbnailWithSharp,
-			buildJpegThumbnailWithJimp,
-		]) {
+		for (const buildThumbnail of [buildJpegThumbnailWithSharp]) {
 			try {
 				const thumbnailResult = await buildThumbnail({ sourceBuffer });
 				if (!thumbnailResult?.jpegThumbnail?.length) {
@@ -1153,10 +1088,7 @@ const normalizeNewsletterImageSendContent = async ({
 		let lastNormalizationError = null;
 
 		if (shouldForceJpeg) {
-			for (const normalizeBuffer of [
-				normalizeImageBufferWithSharp,
-				normalizeImageBufferWithJimp,
-			]) {
+			for (const normalizeBuffer of [normalizeImageBufferWithSharp]) {
 				try {
 					const normalizedResult = await normalizeBuffer({
 						sourceBuffer,
@@ -1176,10 +1108,7 @@ const normalizeNewsletterImageSendContent = async ({
 				}
 			}
 			if (!width || !height) {
-				for (const readImageDimensions of [
-					readImageDimensionsWithSharp,
-					readImageDimensionsWithJimp,
-				]) {
+				for (const readImageDimensions of [readImageDimensionsWithSharp]) {
 					try {
 						const dimensions = await readImageDimensions({ sourceBuffer });
 						if (!dimensions) {
@@ -1204,10 +1133,7 @@ const normalizeNewsletterImageSendContent = async ({
 				outboundMime = normalizedSourceMime || "image/jpeg";
 			}
 		} else {
-			for (const readImageDimensions of [
-				readImageDimensionsWithSharp,
-				readImageDimensionsWithJimp,
-			]) {
+			for (const readImageDimensions of [readImageDimensionsWithSharp]) {
 				try {
 					const dimensions = await readImageDimensions({ sourceBuffer });
 					if (!dimensions) {
@@ -1294,10 +1220,7 @@ const normalizeRegularImageSendContentForWhatsApp = async ({
 			return fallbackToDocument();
 		}
 
-		for (const normalizeBuffer of [
-			normalizeImageBufferWithSharp,
-			normalizeImageBufferWithJimp,
-		]) {
+		for (const normalizeBuffer of [normalizeImageBufferWithSharp]) {
 			try {
 				const normalizedResult = await normalizeBuffer({
 					sourceBuffer,

--- a/tests/whatsappBridge.test.js
+++ b/tests/whatsappBridge.test.js
@@ -1993,12 +1993,11 @@ test("Unsupported Discord AVIF attachments are normalized before WhatsApp send",
 	}
 });
 
-test("Unsupported Discord TIFF attachments fall back to Jimp when sharp is unavailable", async () => {
+test("Unsupported Discord TIFF attachments fall back to document sends when sharp is unavailable", async () => {
 	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
 	try {
 		const sharpMod = await import("sharp");
 		const sharp = sharpMod?.default || sharpMod;
-		const jimp = await import("jimp");
 		const tiffBytes = await sharp({
 			create: {
 				width: 3,
@@ -2013,7 +2012,6 @@ test("Unsupported Discord TIFF attachments fall back to Jimp when sharp is unava
 
 		setImageLibTestOverrides({
 			getImageSharp: async () => null,
-			getImageJimp: async () => jimp,
 		});
 		utils.whatsapp.createDocumentContent = (attachment) => ({
 			image: { url: attachment.url },
@@ -2024,7 +2022,7 @@ test("Unsupported Discord TIFF attachments fall back to Jimp when sharp is unava
 			jid: "120363123456789@s.whatsapp.net",
 			forwardContext: null,
 			message: {
-				id: "dc-static-tiff-jimp-fallback",
+				id: "dc-static-tiff-document-fallback",
 				content: "",
 				cleanContent: "",
 				webhookId: null,
@@ -2057,11 +2055,11 @@ test("Unsupported Discord TIFF attachments fall back to Jimp when sharp is unava
 
 		assert.equal(sent, true);
 		const sentContent = harness.fakeClient.sendCalls[0]?.content || {};
-		assert.ok(Buffer.isBuffer(sentContent.image));
-		assert.equal(sentContent.mimetype, "image/png");
-		assert.equal(sentContent.document, undefined);
-		assert.equal(sentContent.width, 3);
-		assert.equal(sentContent.height, 2);
+		assert.ok(sentContent.document);
+		assert.equal(sentContent.mimetype, "image/tiff");
+		assert.equal(sentContent.image, undefined);
+		assert.equal(sentContent.width, undefined);
+		assert.equal(sentContent.height, undefined);
 	} finally {
 		resetImageLibTestOverrides();
 		harness.cleanup();


### PR DESCRIPTION
Remove the Jimp image processing library in favor of using Sharp exclusively, and bump the version to 2.3.1.