### PR TITLE
Handle expired Discord interactions without crashing WA2DC

### DIFF
--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -766,9 +766,9 @@ class CommandResponder {
 		if (!this.interaction || this.deferred || this.replied) {
 			return;
 		}
+		await this.interaction.deferReply({ ephemeral: this.ephemeral });
 		this.deferred = true;
 		this.replied = true;
-		await this.interaction.deferReply({ ephemeral: this.ephemeral });
 	}
 
 	async send(payload) {
@@ -777,8 +777,9 @@ class CommandResponder {
 		if (this.interaction) {
 			if (this.deferred) {
 				if (!this.firstEditSent) {
+					const reply = await this.interaction.editReply(normalized);
 					this.firstEditSent = true;
-					return this.interaction.editReply(normalized);
+					return reply;
 				}
 				return this.interaction.followUp({
 					...normalized,
@@ -786,11 +787,12 @@ class CommandResponder {
 				});
 			}
 			if (!this.replied) {
-				this.replied = true;
-				return this.interaction.reply({
+				const reply = await this.interaction.reply({
 					...normalized,
 					ephemeral: this.ephemeral,
 				});
+				this.replied = true;
+				return reply;
 			}
 			return this.interaction.followUp({
 				...normalized,
@@ -5244,29 +5246,80 @@ const handleInteractionCommand = async (interaction, commandName) => {
 	await executeCommand(commandName, ctx);
 };
 
+const isUnknownInteractionError = (err) =>
+	Number(err?.code) === 10062 ||
+	Number(err?.rawError?.code) === 10062 ||
+	String(err?.message || "").toLowerCase().includes("unknown interaction");
+
+const handleInteractionCommandFailure = async ({
+	interaction,
+	commandName,
+	err,
+}) => {
+	const logContext = {
+		err,
+		commandName,
+		interactionId: interaction?.id,
+		channelId: interaction?.channelId,
+		customId: interaction?.customId,
+	};
+	if (isUnknownInteractionError(err)) {
+		state.logger?.warn?.(
+			logContext,
+			"Discord rejected the interaction callback before WA2DC could acknowledge it",
+		);
+		return;
+	}
+
+	state.logger?.error?.(logContext, "Slash command handling failed");
+	if (!interaction || interaction.deferred || interaction.replied) {
+		return;
+	}
+
+	try {
+		await interaction.reply({
+			content: "Command failed. Check logs.",
+			ephemeral: interaction.channelId !== state.settings.ControlChannelID,
+		});
+	} catch (replyErr) {
+		state.logger?.warn?.(
+			{ err: replyErr, commandName },
+			"Failed to send interaction error reply",
+		);
+	}
+};
+
 client.on("interactionCreate", async (interaction) => {
-	if (interaction.isButton()) {
-		if (interaction.customId === UPDATE_BUTTON_IDS.APPLY) {
-			await handleInteractionCommand(interaction, "update");
+	try {
+		if (interaction.isButton()) {
+			if (interaction.customId === UPDATE_BUTTON_IDS.APPLY) {
+				await handleInteractionCommand(interaction, "update");
+				return;
+			}
+			if (interaction.customId === UPDATE_BUTTON_IDS.SKIP) {
+				await handleInteractionCommand(interaction, "skipupdate");
+				return;
+			}
+			if (interaction.customId === ROLLBACK_BUTTON_ID) {
+				await handleInteractionCommand(interaction, "rollback");
+				return;
+			}
 			return;
 		}
-		if (interaction.customId === UPDATE_BUTTON_IDS.SKIP) {
-			await handleInteractionCommand(interaction, "skipupdate");
-			return;
-		}
-		if (interaction.customId === ROLLBACK_BUTTON_ID) {
-			await handleInteractionCommand(interaction, "rollback");
-			return;
-		}
-		return;
-	}
 
-	if (!interaction.isCommand?.() && !interaction.isChatInputCommand?.()) {
-		return;
-	}
+		if (!interaction.isCommand?.() && !interaction.isChatInputCommand?.()) {
+			return;
+		}
 
-	const commandName = interaction.commandName?.toLowerCase();
-	await handleInteractionCommand(interaction, commandName);
+		const commandName = interaction.commandName?.toLowerCase();
+		await handleInteractionCommand(interaction, commandName);
+	} catch (err) {
+		await handleInteractionCommandFailure({
+			interaction,
+			commandName: interaction.commandName?.toLowerCase() || interaction.customId,
+			err,
+		});
+	}
 });
 
 client.on("raw", (packet = {}) => {

--- a/tests/updateCommands.test.js
+++ b/tests/updateCommands.test.js
@@ -51,6 +51,7 @@ const createInteraction = ({
 	numberOptions = {},
 	channelOptions = {},
 	userOptions = {},
+	deferReplyError = null,
 }) => {
 	const records = {
 		deferReply: [],
@@ -78,6 +79,9 @@ const createInteraction = ({
 		isChatInputCommand: () => true,
 		async deferReply(payload) {
 			records.deferReply.push(payload);
+			if (deferReplyError) {
+				throw deferReplyError;
+			}
 		},
 		async editReply(payload) {
 			records.editReply.push(payload);
@@ -106,6 +110,80 @@ class FakeDiscordClient extends EventEmitter {
 		return this;
 	}
 }
+
+test("interaction defer Unknown interaction is logged and does not escape the listener", async () => {
+	const originalDiscordUtils = {
+		getGuild: utils.discord.getGuild,
+		getControlChannel: utils.discord.getControlChannel,
+	};
+	const originalSettings = {
+		Token: state.settings.Token,
+		GuildID: state.settings.GuildID,
+		ControlChannelID: state.settings.ControlChannelID,
+	};
+	const originalDcClient = state.dcClient;
+	const originalLogger = state.logger;
+
+	try {
+		state.settings.Token = "TEST_TOKEN";
+		state.settings.GuildID = "guild";
+		state.settings.ControlChannelID = "control";
+		const warnings = [];
+		const errors = [];
+		state.logger = {
+			warn(entry, message) {
+				warnings.push({ entry, message });
+			},
+			error(entry, message) {
+				errors.push({ entry, message });
+			},
+		};
+
+		utils.discord.getGuild = async () => ({
+			commands: { set: async () => {} },
+		});
+		utils.discord.getControlChannel = async () => ({ send: async () => {} });
+
+		const fakeClient = new FakeDiscordClient();
+		setClientFactoryOverrides({ createDiscordClient: () => fakeClient });
+		const discordHandler = await importDiscordHandler(
+			"interaction-unknown-interaction-defer",
+		);
+		state.dcClient = await discordHandler.start();
+		await delay(0);
+
+		const interaction = createInteraction({
+			channelId: "control",
+			commandName: "checkupdate",
+			deferReplyError: Object.assign(new Error("Unknown interaction"), {
+				code: 10062,
+				rawError: { code: 10062 },
+			}),
+		});
+		fakeClient.emit("interactionCreate", interaction);
+		await delay(0);
+
+		assert.equal(interaction.records.deferReply.length, 1);
+		assert.equal(interaction.records.editReply.length, 0);
+		assert.equal(interaction.records.reply.length, 0);
+		assert.equal(errors.length, 0);
+		assert.equal(warnings.length, 1);
+		assert.equal(
+			warnings[0]?.message,
+			"Discord rejected the interaction callback before WA2DC could acknowledge it",
+		);
+	} finally {
+		utils.discord.getGuild = originalDiscordUtils.getGuild;
+		utils.discord.getControlChannel = originalDiscordUtils.getControlChannel;
+
+		state.settings.Token = originalSettings.Token;
+		state.settings.GuildID = originalSettings.GuildID;
+		state.settings.ControlChannelID = originalSettings.ControlChannelID;
+		state.dcClient = originalDcClient;
+		state.logger = originalLogger;
+		resetClientFactoryOverrides();
+	}
+});
 
 test("/checkupdate in control channel refreshes persistent prompt without duplicate full update reply", async () => {
 	const originalDiscordUtils = {


### PR DESCRIPTION
This prevents slash-command `Unknown interaction` (`DiscordAPIError[10062]`) failures from taking down the whole bot.

Changes:
- Catch interaction handler errors locally instead of letting them become fatal unhandled rejections
- Treat expired/unknown Discord interactions as a warning, not a process-ending crash
- Only mark interactions as deferred/replied after Discord accepts the callback
- Add a regression test for `deferReply()` failing with `10062`

Result:
A stale or late slash-command interaction may still fail for that one command, but it no longer drops the WhatsApp connection and triggers a watchdog restart.