### PR TITLE
Implement WhatsApp GIF normalization for Discord attachments with fallback handling

### DIFF
--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -37,6 +37,7 @@ Respect transport constraints when emitting output:
 - when a Discord message contains multiple album-eligible image/video attachments for a normal WhatsApp chat, prefer relaying them as a WhatsApp media album instead of separate standalone sends; keep mixed/unsupported attachment sets on the sequential fallback path
 - do not flatten or duplicate animated Discord media just to satisfy static image normalization paths; when Discord exposes both a GIF file entry and its preview video for the same upload, prefer a single animated send candidate
 - when Discord GIF providers (for example Tenor/Giphy) expose extensionless video URLs plus static preview thumbnails, infer the animated video send from the provider embed and suppress the duplicate preview image
+- when WhatsApp exposes GIFs as `videoMessage` payloads with `gifPlayback`, prefer transcoding them into real Discord GIF attachments when runtime tooling (`ffmpeg`) is available; if transcoding is unavailable or fails, fall back to the original video attachment instead of dropping media
 - prefer the sticker asset URL exposed by Discord over reconstructing sticker CDN/proxy URLs locally; convert Discord sticker assets into WhatsApp sticker payloads when possible, including animated Lottie stickers via the dedicated renderer path
 
 ## Routing gates

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,6 +31,12 @@ WA2DC can mirror Discord voice-style attachments to WhatsApp voice notes (`ptt`)
 - For best compatibility, install `ffmpeg` on the host running WA2DC. The bridge will transcode Discord voice uploads to Opus/Ogg mono before sending.
 - If `ffmpeg` is not installed, WA2DC still attempts a raw audio send, but some voice uploads may fail on WhatsApp clients.
 
+## Why did a WhatsApp GIF arrive on Discord as a video?
+WhatsApp usually exposes GIF sends as short `videoMessage` payloads flagged with `gifPlayback`, not as literal `.gif` files.
+
+- For best compatibility, install `ffmpeg` on the host running WA2DC. The bridge will transcode WhatsApp GIF-playback videos into real Discord GIF attachments when possible.
+- If `ffmpeg` is not installed or transcoding fails, WA2DC falls back to mirroring the original WhatsApp video attachment, so Discord may show a play button instead of an inline GIF.
+
 ## Why did a Discord image arrive on WhatsApp as a file?
 WA2DC now normalizes static unsupported Discord image formats such as pasted WebP before sending them to WhatsApp. This normalization relies on `sharp`. If `sharp` is unavailable in the current runtime or the image still cannot be decoded safely, the bridge falls back to sending it as a regular document so the message is still delivered instead of being dropped.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wa2dc",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wa2dc",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"@adiwajshing/keyed-db": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wa2dc",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
 	"type": "module",
 	"main": "src/runner.js",

--- a/src/internal/whatsappGifToDiscordNormalization.js
+++ b/src/internal/whatsappGifToDiscordNormalization.js
@@ -1,0 +1,152 @@
+import childProcess from "node:child_process";
+
+const WHATSAPP_GIF_TRANSCODE_TIMEOUT_MS = 20 * 1000;
+
+const normalizeMimeType = (value = "") => {
+	if (typeof value !== "string") return "";
+	return value.split(";")[0].trim().toLowerCase();
+};
+
+const replaceFileExtension = (fileName = "", extension = "gif") => {
+	const trimmed = typeof fileName === "string" ? fileName.trim() : "";
+	if (!trimmed) return `videoMessage.${extension}`;
+	if (!trimmed.includes(".")) {
+		return `${trimmed}.${extension}`;
+	}
+	return trimmed.replace(/\.[^.]+$/u, `.${extension}`);
+};
+
+const transcodeVideoBufferToGif = async (inputBuffer) => {
+	if (!inputBuffer?.length) return null;
+	return await new Promise((resolve, reject) => {
+		const ffmpeg = childProcess.spawn(
+			"ffmpeg",
+			[
+				"-hide_banner",
+				"-loglevel",
+				"error",
+				"-i",
+				"pipe:0",
+				"-an",
+				"-vf",
+				"fps=12,split[s0][s1];[s0]palettegen=reserve_transparent=0[p];[s1][p]paletteuse",
+				"-loop",
+				"0",
+				"-f",
+				"gif",
+				"pipe:1",
+			],
+			{ stdio: ["pipe", "pipe", "pipe"] },
+		);
+
+		const stdoutChunks = [];
+		const stderrChunks = [];
+		let completed = false;
+		const finish = (err, output = null) => {
+			if (completed) return;
+			completed = true;
+			clearTimeout(timeout);
+			if (err) {
+				reject(err);
+				return;
+			}
+			resolve(output);
+		};
+		const timeout = setTimeout(() => {
+			ffmpeg.kill("SIGKILL");
+			finish(new Error("ffmpeg_timeout"));
+		}, WHATSAPP_GIF_TRANSCODE_TIMEOUT_MS);
+
+		ffmpeg.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+		ffmpeg.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+		ffmpeg.on("error", (err) => finish(err));
+		ffmpeg.on("close", (code) => {
+			if (code !== 0) {
+				const stderrText = Buffer.concat(stderrChunks).toString("utf8").trim();
+				finish(
+					new Error(`ffmpeg_exit_${code}${stderrText ? `:${stderrText}` : ""}`),
+				);
+				return;
+			}
+			const output = Buffer.concat(stdoutChunks);
+			if (!output.length) {
+				finish(new Error("ffmpeg_empty_output"));
+				return;
+			}
+			finish(null, output);
+		});
+
+		ffmpeg.stdin.on("error", () => {});
+		ffmpeg.stdin.end(inputBuffer);
+	});
+};
+
+export const createWhatsAppGifToDiscordFileNormalizer = ({
+	getLogger = null,
+	transcodeBufferToGif = transcodeVideoBufferToGif,
+} = {}) => {
+	let ffmpegMissingLogged = false;
+	const loggerForCall = () =>
+		typeof getLogger === "function" ? getLogger() : getLogger;
+
+	return async ({
+		attachmentBuffer,
+		fileName,
+		mimetype,
+		jid,
+		messageId,
+	} = {}) => {
+		const normalizedMime = normalizeMimeType(mimetype);
+		const normalizedName =
+			typeof fileName === "string" && fileName.trim()
+				? fileName.trim()
+				: "videoMessage.mp4";
+		if (!attachmentBuffer?.length || !normalizedMime.startsWith("video/")) {
+			return {
+				attachmentBuffer,
+				fileName: normalizedName,
+				contentType: normalizedMime || "application/octet-stream",
+				converted: false,
+			};
+		}
+
+		const logger = loggerForCall();
+		try {
+			const gifBuffer = await transcodeBufferToGif(attachmentBuffer);
+			if (gifBuffer?.length) {
+				return {
+					attachmentBuffer: gifBuffer,
+					fileName: replaceFileExtension(normalizedName, "gif"),
+					contentType: "image/gif",
+					converted: true,
+				};
+			}
+		} catch (err) {
+			if (err?.code === "ENOENT") {
+				if (!ffmpegMissingLogged) {
+					ffmpegMissingLogged = true;
+					logger?.warn?.(
+						"ffmpeg is not installed; WhatsApp GIFs will be mirrored to Discord as videos",
+					);
+				}
+			} else {
+				logger?.debug?.(
+					{
+						err,
+						jid,
+						messageId: messageId || null,
+						fileName: normalizedName,
+					},
+					"Failed to transcode WhatsApp GIF to a Discord GIF attachment",
+				);
+			}
+		}
+
+		return {
+			attachmentBuffer,
+			fileName: normalizedName,
+			contentType: normalizedMime || "video/mp4",
+			converted: false,
+		};
+	};
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,7 @@ import QRCode from "qrcode";
 import * as tar from "tar";
 import { Agent } from "undici";
 import { getImageSharp } from "./imageLibs.js";
+import { createWhatsAppGifToDiscordFileNormalizer } from "./internal/whatsappGifToDiscordNormalization.js";
 import messageStore from "./messageStore.js";
 import state from "./state.js";
 import storage from "./storage.js";
@@ -123,6 +124,10 @@ const UPDATE_BUTTON_IDS = {
 	SKIP: "wa2dc:skip-update",
 };
 const ROLLBACK_BUTTON_ID = "wa2dc:rollback";
+const normalizeWhatsAppGifFileForDiscord =
+	createWhatsAppGifToDiscordFileNormalizer({
+		getLogger: () => state.logger,
+	});
 const resolveLinkPreviewFromContentFn = () => {
 	let moduleExports;
 	if (linkPreview && typeof linkPreview === "object") {
@@ -4457,16 +4462,45 @@ const whatsapp = {
 		const largeFile = fileLength > state.settings.DiscordFileSizeLimit;
 		if (largeFile && !state.settings.LocalDownloads) return -1;
 		try {
+			const baseName = this.getFilename(msg, nMsgType);
 			if (largeFile && state.settings.LocalDownloads) {
 				return {
-					name: this.getFilename(msg, nMsgType),
+					name: baseName,
 					downloadCtx: rawMsg,
 					msgType: nMsgType,
 					largeFile: true,
 				};
 			}
+			if (nMsgType === "videoMessage" && msg.gifPlayback) {
+				const attachmentBuffer = Buffer.from(
+					await downloadMediaMessage(
+						rawMsg,
+						"buffer",
+						{},
+						{
+							logger: state.logger,
+							reuploadRequest: state.waClient.updateMediaMessage,
+						},
+					),
+				);
+				const normalizedGif = await normalizeWhatsAppGifFileForDiscord({
+					attachmentBuffer,
+					fileName: baseName,
+					mimetype: msg.mimetype,
+					jid: remoteJid,
+					messageId: this.getId(rawMsg),
+				});
+				return {
+					name: normalizedGif.fileName,
+					attachment: normalizedGif.attachmentBuffer,
+					contentType: normalizedGif.contentType,
+					largeFile,
+					downloadCtx: rawMsg,
+					msgType: nMsgType,
+				};
+			}
 			return {
-				name: this.getFilename(msg, nMsgType),
+				name: baseName,
 
 				attachment: await downloadMediaMessage(
 					rawMsg,

--- a/tests/whatsappGifToDiscordNormalization.test.js
+++ b/tests/whatsappGifToDiscordNormalization.test.js
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createWhatsAppGifToDiscordFileNormalizer } from "../src/internal/whatsappGifToDiscordNormalization.js";
+
+test("WhatsApp GIF normalizer leaves non-video media unchanged", async () => {
+	const normalizeWhatsAppGifFileForDiscord =
+		createWhatsAppGifToDiscordFileNormalizer();
+	const sourceBuffer = Buffer.from("not-a-video", "utf8");
+	const normalized = await normalizeWhatsAppGifFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "photo.png",
+		mimetype: "image/png",
+	});
+
+	assert.equal(normalized.converted, false);
+	assert.equal(normalized.fileName, "photo.png");
+	assert.equal(normalized.contentType, "image/png");
+	assert.equal(normalized.attachmentBuffer, sourceBuffer);
+});
+
+test("WhatsApp GIF normalizer converts video buffers into Discord GIF attachments", async () => {
+	const outputBuffer = Buffer.from("gif89a", "utf8");
+	const normalizeWhatsAppGifFileForDiscord =
+		createWhatsAppGifToDiscordFileNormalizer({
+			transcodeBufferToGif: async (inputBuffer) => {
+				assert.equal(inputBuffer.toString("utf8"), "mp4-bytes");
+				return outputBuffer;
+			},
+		});
+
+	const normalized = await normalizeWhatsAppGifFileForDiscord({
+		attachmentBuffer: Buffer.from("mp4-bytes", "utf8"),
+		fileName: "videoMessage.mp4",
+		mimetype: "video/mp4",
+	});
+
+	assert.equal(normalized.converted, true);
+	assert.equal(normalized.fileName, "videoMessage.gif");
+	assert.equal(normalized.contentType, "image/gif");
+	assert.equal(normalized.attachmentBuffer, outputBuffer);
+});
+
+test("WhatsApp GIF normalizer falls back to video when ffmpeg is unavailable", async () => {
+	const warnings = [];
+	const normalizeWhatsAppGifFileForDiscord =
+		createWhatsAppGifToDiscordFileNormalizer({
+			getLogger: () => ({
+				warn(message) {
+					warnings.push(message);
+				},
+				debug() {},
+			}),
+			transcodeBufferToGif: async () => {
+				const err = new Error("spawn ffmpeg ENOENT");
+				err.code = "ENOENT";
+				throw err;
+			},
+		});
+	const sourceBuffer = Buffer.from("mp4-bytes", "utf8");
+
+	const first = await normalizeWhatsAppGifFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "clip.mp4",
+		mimetype: "video/mp4",
+	});
+	const second = await normalizeWhatsAppGifFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "clip.mp4",
+		mimetype: "video/mp4",
+	});
+
+	assert.equal(first.converted, false);
+	assert.equal(first.fileName, "clip.mp4");
+	assert.equal(first.contentType, "video/mp4");
+	assert.equal(first.attachmentBuffer, sourceBuffer);
+	assert.equal(second.converted, false);
+	assert.deepEqual(warnings, [
+		"ffmpeg is not installed; WhatsApp GIFs will be mirrored to Discord as videos",
+	]);
+});


### PR DESCRIPTION
Introduce functionality to transcode WhatsApp GIFs into Discord GIF attachments when possible, utilizing `ffmpeg`. If transcoding fails or is unavailable, the original video is sent instead. This enhances media compatibility between platforms.