### PR TITLE
Pin transitive lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2574,9 +2574,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.snakecase": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	},
 	"pkg": {},
 	"overrides": {
-		"lodash": "4.17.23",
+		"lodash": "4.18.1",
 		"form-data": "4.0.5",
 		"@whiskeysockets/baileys": {
 			"music-metadata": "11.12.3"


### PR DESCRIPTION
Fix Dependabot alerts for transitive `lodash` pulled in via `discord.js`.

Changes:
- update `package.json` override from `lodash@4.17.23` to `4.18.1`
- regenerate `package-lock.json`