### PR TITLE
Add configurable WA->Discord media burst size

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -215,9 +215,16 @@ How to find PN/LID:
 
 Defaults (out of the box):
 
+- WhatsApp → Discord media bursts use batches of `10` attachments (`/setwamediaburstsize` can lower this for slower machines or unstable connections).
 - Local downloads are disabled (`/localdownloads enabled:true` to turn on).
 - Download directory is `./downloads` and pruning is disabled (`/setdownloadlimit`, `/setdownloadmaxage`, `/setdownloadminfree` all default to `0` = off).
 - Local download server is disabled; when enabled it defaults to local-only (`127.0.0.1` bind, `localhost` URLs, port `8080`).
+
+### `/setwamediaburstsize`
+Set how many WhatsApp attachments WA2DC uploads to Discord per batch when mirroring media bursts.  
+Usage: `/setwamediaburstsize count:<1-10>`  
+Default: `10`  
+Lower values can help on slower machines or unstable connections, at the cost of producing more Discord messages for large WhatsApp image bursts.
 - Download links are signed (survive restarts) and never expire by default (`/setdownloadlinkttl seconds:0`).
 
 To make download links reachable from other devices (phone/PC), you usually want:

--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -32,6 +32,7 @@ Respect transport constraints when emitting output:
 - 2000-character message limit
 - use `utils.discord.partitionText(...)` for long responses
 - respect file-size gating (for example `DiscordFileSizeLimit`)
+- keep WhatsApp-backed Discord attachment uploads bounded during media bursts; honor `state.settings.WhatsAppDiscordMediaBurstSize` and do not exceed Discord's 10-file upload limit
 - preserve Discord -> WhatsApp attachment delivery for unsupported static image formats by normalizing them to WhatsApp-safe image payloads when possible, and fall back to document delivery instead of dropping the message when normalization fails
 - precompute outbound `jpegThumbnail` data for Discord -> WhatsApp image sends when possible so packaged Baileys builds do not need to discover image tooling at send time
 - when a Discord message contains multiple album-eligible image/video attachments for a normal WhatsApp chat, prefer relaying them as a WhatsApp media album instead of separate standalone sends; keep mixed/unsupported attachment sets on the sequential fallback path

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1066,7 +1066,7 @@ const sendWhatsappMessage = async (
 			return chunks;
 		};
 
-		const fileChunks = chunkArray(files, 10);
+		const fileChunks = utils.discord.chunkWebhookFilesForSend(files);
 		const normalizedMessageIds = [
 			...new Set(
 				(messageIds.length ? messageIds : [message.id])
@@ -4668,6 +4668,32 @@ const commandHandlers = {
 			} else {
 				await ctx.reply("Please provide a valid size in bytes.");
 			}
+		},
+	},
+	setwamediaburstsize: {
+		description:
+			"Set how many WhatsApp attachments are uploaded to Discord per batch.",
+		options: [
+			{
+				name: "count",
+				description:
+					"Attachment count per Discord upload batch for WhatsApp media bursts (1-10).",
+				type: ApplicationCommandOptionTypes.INTEGER,
+				required: true,
+			},
+		],
+		async execute(ctx) {
+			const count = ctx.getIntegerOption("count");
+			if (!Number.isInteger(count) || count < 1 || count > 10) {
+				await ctx.reply(
+					"Please provide a valid attachment count between 1 and 10.",
+				);
+				return;
+			}
+			state.settings.WhatsAppDiscordMediaBurstSize = count;
+			await ctx.reply(
+				`WhatsApp to Discord media burst size is set to ${count} attachment${count === 1 ? "" : "s"} per batch.`,
+			);
 		},
 	},
 	localdownloadserver: {

--- a/src/state.js
+++ b/src/state.js
@@ -22,6 +22,7 @@ const state = {
 		DownloadDirMaxAgeDays: 0,
 		DownloadDirMinFreeGB: 0,
 		DiscordFileSizeLimit: 8 * 1024 * 1024,
+		WhatsAppDiscordMediaBurstSize: 10,
 		LocalDownloadServer: false,
 		LocalDownloadServerHost: "localhost",
 		LocalDownloadServerBindHost: "127.0.0.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,6 +62,9 @@ const buildUnicodeMentionRegex = (token) =>
 	new RegExp(`@${escapeRegex(token)}(?=$|\\s|[\\p{P}\\p{S}])`, "giu");
 const buildWordBoundaryMentionRegex = (token) =>
 	new RegExp(`@${escapeRegex(token)}(?=\\W|$)`, "g");
+const asLower = (value) => String(value || "").toLowerCase();
+const includesHint = (text, hints) =>
+	hints.some((hint) => text.includes(asLower(hint)));
 const isUnknownDisplayName = (value = "") =>
 	String(value).trim().toLowerCase() === UNKNOWN_DISPLAY_NAME.toLowerCase();
 const isUnknownOrSelfDisplayName = (value = "") => {
@@ -115,10 +118,34 @@ const LINK_PREVIEW_MAX_REDIRECTS = 5;
 const LINK_PREVIEW_FETCH_OPTS = { timeout: LINK_PREVIEW_FETCH_TIMEOUT_MS };
 const LINK_PREVIEW_MAX_BYTES = 1024 * 1024;
 const LINK_PREVIEW_THUMB_MAX_BYTES = 8 * 1024 * 1024;
+const DISCORD_MAX_FILES_PER_MESSAGE = 10;
 const EXPLICIT_URL_REGEX = /<?https?:\/\/[^\s>]+>?/i;
 const BARE_URL_REGEX =
 	/(?:^|[\s<])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[\w\-./?%&=+#]*)?)(?=$|[\s>)\],.;!?])/i;
 const TRAILING_PUNCTUATION_REGEX = /[)\],.;!?]+$/;
+const RETRYABLE_WEBHOOK_MESSAGE_HINTS = [
+	"aborted",
+	"fetch failed",
+	"terminated",
+	"other side closed",
+	"socket",
+	"timed out",
+	"timeout",
+	"econnreset",
+	"etimedout",
+	"ehostunreach",
+	"enotfound",
+	"eai_again",
+];
+const RETRYABLE_WEBHOOK_CODE_HINTS = [
+	"ABORT_ERR",
+	"UND_ERR",
+	"ECONNRESET",
+	"ETIMEDOUT",
+	"EHOSTUNREACH",
+	"ENOTFOUND",
+	"EAI_AGAIN",
+];
 const UPDATE_BUTTON_IDS = {
 	APPLY: "wa2dc:update",
 	SKIP: "wa2dc:skip-update",
@@ -638,6 +665,52 @@ const fetchPreviewBuffer = async (
 			clearTimeout(timeout);
 		}
 	}
+};
+
+const isRetryableWebhookTransportError = (err) => {
+	const messageText = asLower(
+		[err?.message, err?.cause?.message].filter(Boolean).join(" | "),
+	);
+	const codeText = asLower(
+		[err?.code, err?.cause?.code].filter(Boolean).join(" | "),
+	);
+	const stackText = asLower(
+		[err?.stack, err?.cause?.stack].filter(Boolean).join("\n"),
+	);
+	return (
+		includesHint(messageText, RETRYABLE_WEBHOOK_MESSAGE_HINTS) ||
+		includesHint(codeText, RETRYABLE_WEBHOOK_CODE_HINTS) ||
+		stackText.includes("node:internal/deps/undici/undici") ||
+		stackText.includes("/undici/")
+	);
+};
+
+const isWhatsAppStreamBackedDiscordFile = (file) =>
+	Boolean(file?.downloadCtx) && typeof file?.attachment?.pipe === "function";
+
+const resolveWhatsAppDiscordMediaBurstSize = (value) => {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return DISCORD_MAX_FILES_PER_MESSAGE;
+	}
+	return Math.min(Math.floor(parsed), DISCORD_MAX_FILES_PER_MESSAGE);
+};
+
+const chunkDiscordWebhookFilesForSend = (files = []) => {
+	const normalizedFiles = Array.isArray(files) ? files.filter(Boolean) : [];
+	if (!normalizedFiles.length) {
+		return [];
+	}
+	const chunkSize = normalizedFiles.some(isWhatsAppStreamBackedDiscordFile)
+		? resolveWhatsAppDiscordMediaBurstSize(
+				state.settings?.WhatsAppDiscordMediaBurstSize,
+			)
+		: DISCORD_MAX_FILES_PER_MESSAGE;
+	const chunks = [];
+	for (let i = 0; i < normalizedFiles.length; i += chunkSize) {
+		chunks.push(normalizedFiles.slice(i, i + chunkSize));
+	}
+	return chunks;
 };
 
 const sanitizeFileName = (name = "", fallback = "file") => {
@@ -2469,6 +2542,10 @@ const discord = {
 	partitionText(text) {
 		return text.match(/(.|[\r\n]){1,2000}/g) || [];
 	},
+	isRetryableWebhookTransportError,
+	chunkWebhookFilesForSend(files) {
+		return chunkDiscordWebhookFilesForSend(files);
+	},
 	async sendPartitioned(channel, text) {
 		if (!channel || !text) return;
 		const parts = this.partitionText(text);
@@ -2821,7 +2898,8 @@ const discord = {
 			err?.name === "AbortError" ||
 			err?.name === "AbortError2" ||
 			err?.code === "ABORT_ERR" ||
-			/aborted/i.test(err?.message || "");
+			/aborted/i.test(err?.message || "") ||
+			isRetryableWebhookTransportError(err);
 
 		const extractFileNames = (files) => {
 			if (!Array.isArray(files)) return [];
@@ -3052,7 +3130,7 @@ const discord = {
 					lastAbortError = err;
 					state.logger?.warn(
 						{ err, attempt: attempt + 1 },
-						"Discord webhook request was aborted.",
+						"Discord webhook request failed with a retryable transport error.",
 					);
 					if (!attachmentsRetryable) {
 						state.logger?.warn(
@@ -3075,8 +3153,8 @@ const discord = {
 		const fileNames = extractFileNames(originalFiles);
 		const attemptText = ` after ${attemptsForMessage} attempt${attemptsForMessage === 1 ? "" : "s"}`;
 		const attachmentNotice = fileNames.length
-			? ` Discord aborted the upload${attemptText} for: ${fileNames.join(", ")}.`
-			: ` Discord aborted the upload${attemptText}.`;
+			? ` Discord failed to upload${attemptText} for: ${fileNames.join(", ")}.`
+			: ` Discord failed to upload${attemptText}.`;
 		const originalContent =
 			typeof args.content === "string" ? args.content.trim() : "";
 		const fallbackParts = [];
@@ -3096,7 +3174,7 @@ const discord = {
 		}
 		state.logger?.error(
 			{ err: lastAbortError, attempts: attemptsForMessage },
-			"Discord webhook request was aborted repeatedly; sending fallback message.",
+			"Discord webhook request failed repeatedly with a retryable transport error; sending fallback message.",
 		);
 		return await webhook.send(fallbackArgs);
 	},

--- a/tests/discordWebhookUploadResilience.test.js
+++ b/tests/discordWebhookUploadResilience.test.js
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+
+import state from "../src/state.js";
+import utils from "../src/utils.js";
+
+test("Discord webhook transport classifier treats fetch timeout failures as retryable", () => {
+	const timeoutError = new AggregateError([], "connect timed out");
+	timeoutError.code = "ETIMEDOUT";
+
+	const err = new TypeError("fetch failed");
+	err.cause = timeoutError;
+	err.stack =
+		"TypeError: fetch failed\n    at node:internal/deps/undici/undici:16416:13";
+
+	assert.equal(utils.discord.isRetryableWebhookTransportError(err), true);
+});
+
+test("WhatsApp-backed Discord uploads honor the configured burst size", () => {
+	const originalBurstSize = state.settings.WhatsAppDiscordMediaBurstSize;
+	try {
+		state.settings.WhatsAppDiscordMediaBurstSize = 3;
+		const files = Array.from({ length: 7 }, (_, idx) => ({
+			name: `image-${idx + 1}.jpg`,
+			attachment: Readable.from([Buffer.from("image")]),
+			downloadCtx: { id: `wa-${idx + 1}` },
+		}));
+
+		const chunks = utils.discord.chunkWebhookFilesForSend(files);
+
+		assert.deepEqual(
+			chunks.map((chunk) => chunk.length),
+			[3, 3, 1],
+		);
+	} finally {
+		state.settings.WhatsAppDiscordMediaBurstSize = originalBurstSize;
+	}
+});
+
+test("WhatsApp-backed Discord uploads default to Discord's full attachment batch size", () => {
+	const originalBurstSize = state.settings.WhatsAppDiscordMediaBurstSize;
+	try {
+		state.settings.WhatsAppDiscordMediaBurstSize = 10;
+		const files = Array.from({ length: 11 }, (_, idx) => ({
+			name: `image-${idx + 1}.jpg`,
+			attachment: Readable.from([Buffer.from("image")]),
+			downloadCtx: { id: `wa-${idx + 1}` },
+		}));
+
+		const chunks = utils.discord.chunkWebhookFilesForSend(files);
+
+		assert.deepEqual(
+			chunks.map((chunk) => chunk.length),
+			[10, 1],
+		);
+	} finally {
+		state.settings.WhatsAppDiscordMediaBurstSize = originalBurstSize;
+	}
+});
+
+test("Buffered Discord uploads still use the full Discord attachment batch size", () => {
+	const files = Array.from({ length: 11 }, (_, idx) => ({
+		name: `image-${idx + 1}.jpg`,
+		attachment: Buffer.from("image"),
+	}));
+
+	const chunks = utils.discord.chunkWebhookFilesForSend(files);
+
+	assert.deepEqual(
+		chunks.map((chunk) => chunk.length),
+		[10, 1],
+	);
+});

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -7,6 +7,7 @@ test("Default settings include DownloadDir", () => {
 	assert.equal(settings.DownloadDir, "./downloads");
 	assert.equal(settings.DiscordEmbedsToWhatsApp, false);
 	assert.equal(settings.redirectAnnouncementWebhooks, false);
+	assert.equal(settings.WhatsAppDiscordMediaBurstSize, 10);
 });
 
 test("sentMessages starts empty", () => {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -70,6 +70,7 @@ test("parseSettings merges defaults when older settings are missing keys", async
 		assert.equal(settings.LocalDownloads, false);
 		assert.equal(settings.NewsletterMediaUrlFallback, false);
 		assert.equal(settings.PinDurationSeconds, 7 * 24 * 60 * 60);
+		assert.equal(settings.WhatsAppDiscordMediaBurstSize, 10);
 	});
 	restoreObject(state.settings, settingsSnapshot);
 });

--- a/tests/updateCommands.test.js
+++ b/tests/updateCommands.test.js
@@ -1028,3 +1028,65 @@ test("/poll in a newsletter-linked channel falls back to text when interactive a
 		resetClientFactoryOverrides();
 	}
 });
+
+test("/setwamediaburstsize updates WhatsApp to Discord media burst size", async () => {
+	const originalDiscordUtils = {
+		getGuild: utils.discord.getGuild,
+		getControlChannel: utils.discord.getControlChannel,
+	};
+	const originalSettings = {
+		Token: state.settings.Token,
+		GuildID: state.settings.GuildID,
+		ControlChannelID: state.settings.ControlChannelID,
+		WhatsAppDiscordMediaBurstSize:
+			state.settings.WhatsAppDiscordMediaBurstSize,
+	};
+	const originalDcClient = state.dcClient;
+
+	try {
+		state.settings.Token = "TEST_TOKEN";
+		state.settings.GuildID = "guild";
+		state.settings.ControlChannelID = "control";
+		state.settings.WhatsAppDiscordMediaBurstSize = 10;
+
+		utils.discord.getGuild = async () => ({
+			commands: { set: async () => {} },
+		});
+		utils.discord.getControlChannel = async () => ({ send: async () => {} });
+
+		const fakeClient = new FakeDiscordClient();
+		setClientFactoryOverrides({ createDiscordClient: () => fakeClient });
+		const discordHandler = await importDiscordHandler("set-wa-media-burst-size");
+		state.dcClient = await discordHandler.start();
+		await delay(0);
+
+		const interaction = createInteraction({
+			channelId: "control",
+			commandName: "setwamediaburstsize",
+			integerOptions: {
+				count: 4,
+			},
+		});
+		fakeClient.emit("interactionCreate", interaction);
+		await delay(0);
+
+		assert.equal(state.settings.WhatsAppDiscordMediaBurstSize, 4);
+		assert.equal(interaction.records.editReply.length, 1);
+		assert.equal(
+			interaction.records.editReply[0]?.content,
+			"WhatsApp to Discord media burst size is set to 4 attachments per batch.",
+		);
+	} finally {
+		utils.discord.getGuild = originalDiscordUtils.getGuild;
+		utils.discord.getControlChannel = originalDiscordUtils.getControlChannel;
+
+		state.settings.Token = originalSettings.Token;
+		state.settings.GuildID = originalSettings.GuildID;
+		state.settings.ControlChannelID = originalSettings.ControlChannelID;
+		state.settings.WhatsAppDiscordMediaBurstSize =
+			originalSettings.WhatsAppDiscordMediaBurstSize;
+
+		state.dcClient = originalDcClient;
+		resetClientFactoryOverrides();
+	}
+});


### PR DESCRIPTION
This adds a small mitigation for environments that struggle when WhatsApp sends a lot of media at once.

What changed:
- added a configurable WhatsApp -> Discord media burst size setting
- added `/setwamediaburstsize count:<1-10>`
- kept the default at `10` to preserve previous behavior
- if a machine/network is less stable, users can lower it to `3` or `1`
- improved retry handling for timeout-style Discord webhook transport errors
- added tests and docs

Why:
Some users hit `ETIMEDOUT` / stream `515` errors when a large burst of WhatsApp images is mirrored to Discord. I couldn’t reproduce it reliably locally, so instead of hard-forcing a slower path for everyone, this makes the burst size tunable for affected setups.