### PR TITLE
Update Baileys to rc10 with Android browser patch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,12 +43,13 @@ Originally created by [Fatih Kilic](https://github.com/FKLC), now maintained by 
 
 ## Baileys 7 migration
 
-This repository currently pins the published npm package `@whiskeysockets/baileys@7.0.0-rc.9`. Upstream outlines every breaking change in their migration article: [https://whiskey.so/migrate-latest](https://whiskey.so/migrate-latest). Notes and common workarounds:
+This repository currently pins the published npm package `@whiskeysockets/baileys@7.0.0-rc10`. Upstream outlines every breaking change in their migration article: [https://whiskey.so/migrate-latest](https://whiskey.so/migrate-latest). Notes and common workarounds:
 
 **Notes**
 
 - Local Identifiers (LIDs) are now preferred over PN-based JIDs. The bot listens for `lid-mapping.update` events, migrates stored chats/whitelists as WhatsApp reveals PN↔LID pairs, and always talks to the chat using the identifier WhatsApp considers canonical.
-- The Signal auth store seeds the newly required `lid-mapping`, `tctoken`, `device-list`, and `device-index` namespaces so rc.9 can write those blobs safely.
+- WA2DC applies a small postinstall patch for upstream PR 2201 so `Browsers.android('13')` remains available while running rc10.
+- The Signal auth store seeds the newly required `lid-mapping`, `tctoken`, `device-list`, and `device-index` namespaces so rc10 can write those blobs safely.
 
 **Common issues & workarounds**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
 		"": {
 			"name": "wa2dc",
 			"version": "2.4.0-alpha.0",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@adiwajshing/keyed-db": "^0.2.4",
-				"@whiskeysockets/baileys": "github:WhiskeySockets/Baileys#android-browser",
+				"@whiskeysockets/baileys": "7.0.0-rc10",
 				"canvas": "^3.2.3",
 				"discord.js": "^14.25.1",
 				"jsdom": "^29.0.1",
@@ -1590,9 +1591,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -1618,9 +1619,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -1636,9 +1637,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sapphire/async-queue": {
@@ -1732,22 +1733,22 @@
 			}
 		},
 		"node_modules/@whiskeysockets/baileys": {
-			"name": "baileys",
-			"version": "7.0.0-rc.9",
-			"resolved": "git+ssh://git@github.com/WhiskeySockets/Baileys.git#bb856356f806e00b0a0c3522b907fa1137d21c9d",
+			"version": "7.0.0-rc10",
+			"resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc10.tgz",
+			"integrity": "sha512-tVHZRIE06HlQajHcLEsCa+gnH5z+dAXPjwHsGXDNY9/Y0iqbymQzHLvh4tMH/pi/ea/D617qCQhNkDT2B0tufg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/node-cache": "^1.4.0",
 				"@hapi/boom": "^9.1.3",
 				"async-mutex": "^0.5.0",
-				"libsignal": "git+https://github.com/whiskeysockets/libsignal-node",
+				"libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
 				"lru-cache": "^11.1.0",
-				"music-metadata": "^11.7.0",
+				"music-metadata": "^11.12.3",
 				"p-queue": "^9.0.0",
 				"pino": "^9.6",
-				"protobufjs": "^7.2.4",
-				"whatsapp-rust-bridge": "0.5.2",
+				"protobufjs": "^7.5.6",
+				"whatsapp-rust-bridge": "0.5.3",
 				"ws": "^8.13.0"
 			},
 			"engines": {
@@ -1755,7 +1756,7 @@
 			},
 			"peerDependencies": {
 				"audio-decode": "^2.1.3",
-				"jimp": "^1.6.0",
+				"jimp": "^1.6.1",
 				"link-preview-js": "^3.0.0",
 				"sharp": "*"
 			},
@@ -3143,22 +3144,22 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+			"integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/codegen": "^2.0.5",
 				"@protobufjs/eventemitter": "^1.1.0",
 				"@protobufjs/fetch": "^1.1.0",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/inquire": "^1.1.1",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
 				"long": "^5.0.0"
 			},
@@ -3783,9 +3784,9 @@
 			}
 		},
 		"node_modules/whatsapp-rust-bridge": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.2.tgz",
-			"integrity": "sha512-6KBRNvxg6WMIwZ/euA8qVzj16qxMBzLllfmaJIP1JGAAfSvwn6nr8JDOMXeqpXPEOl71UfOG+79JwKEoT2b1Fw==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.3.tgz",
+			"integrity": "sha512-Xb3GAgtWQQJ30oI4a4pjM4+YUeli9CMLTwTIewUrb+AJMFElIkiT5uo+j1Zhc+amiV0Jj+LfX76c/EEZirJbGA==",
 			"license": "MIT"
 		},
 		"node_modules/whatwg-mimetype": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@whiskeysockets/baileys": "7.0.0-rc10",
 				"canvas": "^3.2.3",
 				"discord.js": "^14.25.1",
-				"jsdom": "^29.0.1",
+				"jsdom": "^29.1.0",
 				"link-preview-js": "3.2.0",
 				"lottie-web": "^5.13.0",
 				"pino": "^10.3.1",
@@ -25,7 +25,7 @@
 				"undici": "^7.24.6"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.10",
+				"@biomejs/biome": "^2.4.13",
 				"esbuild": "^0.28.0"
 			},
 			"engines": {
@@ -86,9 +86,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
-			"integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+			"integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -102,20 +102,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.12",
-				"@biomejs/cli-darwin-x64": "2.4.12",
-				"@biomejs/cli-linux-arm64": "2.4.12",
-				"@biomejs/cli-linux-arm64-musl": "2.4.12",
-				"@biomejs/cli-linux-x64": "2.4.12",
-				"@biomejs/cli-linux-x64-musl": "2.4.12",
-				"@biomejs/cli-win32-arm64": "2.4.12",
-				"@biomejs/cli-win32-x64": "2.4.12"
+				"@biomejs/cli-darwin-arm64": "2.4.13",
+				"@biomejs/cli-darwin-x64": "2.4.13",
+				"@biomejs/cli-linux-arm64": "2.4.13",
+				"@biomejs/cli-linux-arm64-musl": "2.4.13",
+				"@biomejs/cli-linux-x64": "2.4.13",
+				"@biomejs/cli-linux-x64-musl": "2.4.13",
+				"@biomejs/cli-win32-arm64": "2.4.13",
+				"@biomejs/cli-win32-x64": "2.4.13"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
-			"integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+			"integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -130,9 +130,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
-			"integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+			"integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
 			"cpu": [
 				"x64"
 			],
@@ -147,9 +147,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
-			"integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+			"integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -164,9 +164,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
-			"integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+			"integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
 			"cpu": [
 				"arm64"
 			],
@@ -181,9 +181,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
-			"integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+			"integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -198,9 +198,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
-			"integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+			"integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
 			"cpu": [
 				"x64"
 			],
@@ -215,9 +215,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
-			"integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+			"integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -232,9 +232,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
-			"integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+			"integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2582,27 +2582,27 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "29.0.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+			"version": "29.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+			"integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^5.1.5",
-				"@asamuzakjp/dom-selector": "^7.0.6",
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
 				"@bramus/specificity": "^2.4.2",
-				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
 				"@exodus/bytes": "^1.15.0",
 				"css-tree": "^3.2.1",
 				"data-urls": "^7.0.0",
 				"decimal.js": "^10.6.0",
 				"html-encoding-sniffer": "^6.0.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.7",
-				"parse5": "^8.0.0",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
 				"tough-cookie": "^6.0.1",
-				"undici": "^7.24.5",
+				"undici": "^7.25.0",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^8.0.1",
 				"whatwg-mimetype": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@whiskeysockets/baileys": "7.0.0-rc10",
 		"canvas": "^3.2.3",
 		"discord.js": "^14.25.1",
-		"jsdom": "^29.0.1",
+		"jsdom": "^29.1.0",
 		"link-preview-js": "3.2.0",
 		"lottie-web": "^5.13.0",
 		"pino": "^10.3.1",
@@ -39,7 +39,7 @@
 		"undici": "^7.24.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.10",
+		"@biomejs/biome": "^2.4.13",
 		"esbuild": "^0.28.0"
 	},
 	"pkg": {},

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"main": "src/runner.js",
 	"scripts": {
 		"start": "node src/runner.js",
+		"postinstall": "node scripts/patchBaileysAndroidBrowser.js",
 		"docs": "npx -y docsify-cli@4.4.4 serve docs",
 		"bundle": "esbuild src/runner.js --bundle --platform=node --format=esm --external:sharp --external:qrcode-terminal --external:link-preview-js --target=node24 --banner:js=\"import { createRequire as __esbuildCreateRequire } from 'module'; const require = __esbuildCreateRequire(import.meta.url);\" --outfile=out.js",
 		"bundle:pkg": "node scripts/buildPkgBundle.js",
@@ -24,7 +25,7 @@
 	},
 	"dependencies": {
 		"@adiwajshing/keyed-db": "^0.2.4",
-		"@whiskeysockets/baileys": "github:WhiskeySockets/Baileys#android-browser",
+		"@whiskeysockets/baileys": "7.0.0-rc10",
 		"canvas": "^3.2.3",
 		"discord.js": "^14.25.1",
 		"jsdom": "^29.0.1",

--- a/scripts/patchBaileysAndroidBrowser.js
+++ b/scripts/patchBaileysAndroidBrowser.js
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const packageRoot = path.resolve(
+	"node_modules",
+	"@whiskeysockets",
+	"baileys",
+);
+
+const replacements = [
+	{
+		file: "lib/Utils/browser-utils.js",
+		before:
+			"    windows: browser => ['Windows', browser, '10.0.22631'],\n" +
+			"    /** The appropriate browser based on your OS & release */",
+		after:
+			"    windows: browser => ['Windows', browser, '10.0.22631'],\n" +
+			"    android: browser => [browser, 'Android', ''],\n" +
+			"    /** The appropriate browser based on your OS & release */",
+	},
+	{
+		file: "lib/Types/index.d.ts",
+		before:
+			"    windows(browser: string): [string, string, string];\n" +
+			"    appropriate(browser: string): [string, string, string];",
+		after:
+			"    windows(browser: string): [string, string, string];\n" +
+			"    android(browser: string): [string, string, string];\n" +
+			"    appropriate(browser: string): [string, string, string];",
+	},
+	{
+		file: "lib/Utils/validate-connection.js",
+		before: "        platform: proto.ClientPayload.UserAgent.Platform.WEB,",
+		after:
+			"        platform: config.browser[1].toLocaleLowerCase().includes('android')\n" +
+			"            ? proto.ClientPayload.UserAgent.Platform.ANDROID\n" +
+			"            : proto.ClientPayload.UserAgent.Platform.WEB,",
+	},
+	{
+		file: "lib/Utils/validate-connection.js",
+		before: "    payload.webInfo = getWebInfo(config);",
+		after:
+			"    if (!config.browser[1].toLocaleLowerCase().includes('android')) {\n" +
+			"        payload.webInfo = getWebInfo(config);\n" +
+			"    }",
+	},
+	{
+		file: "lib/Utils/validate-connection.js",
+		before:
+			"const getPlatformType = (platform) => {\n" +
+			"    const platformType = platform.toUpperCase();\n" +
+			"    return (proto.DeviceProps.PlatformType[platformType] ||",
+		after:
+			"const getPlatformType = (platform) => {\n" +
+			"    const platformType = platform.toUpperCase();\n" +
+			"    if (platformType === 'ANDROID') {\n" +
+			"        return proto.DeviceProps.PlatformType.ANDROID_PHONE;\n" +
+			"    }\n" +
+			"    return (proto.DeviceProps.PlatformType[platformType] ||",
+	},
+	{
+		file: "lib/Socket/socket.js",
+		marker: "Using the Android browser is experimental",
+		before: "    const syncDisabled =",
+		after:
+			"    if (browser[1].toLocaleLowerCase().includes('android')) {\n" +
+			"        logger.warn('\\u26a0\\ufe0f Using the Android browser is experimental and may lead to unexpected behavior. Use at your own risk.');\n" +
+			"    }\n" +
+			"    const syncDisabled =",
+	},
+];
+
+const replaceOnce = async ({ file, marker, before, after }) => {
+	const target = path.join(packageRoot, file);
+	const content = await fs.readFile(target, "utf8");
+	if (content.includes(marker || after)) {
+		return false;
+	}
+	if (!content.includes(before)) {
+		throw new Error(`Could not apply Baileys Android browser patch to ${file}`);
+	}
+	await fs.writeFile(target, content.replace(before, after));
+	return true;
+};
+
+const main = async () => {
+	const packageJson = JSON.parse(
+		await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+	);
+	if (packageJson.version !== "7.0.0-rc10") {
+		throw new Error(
+			`Baileys Android browser patch expects 7.0.0-rc10, found ${packageJson.version}`,
+		);
+	}
+
+	const changed = [];
+	for (const replacement of replacements) {
+		if (await replaceOnce(replacement)) {
+			changed.push(replacement.file);
+		}
+	}
+
+	if (changed.length > 0) {
+		console.log(
+			`Applied Baileys PR 2201 Android browser patch to ${[
+				...new Set(changed),
+			].join(", ")}`,
+		);
+	}
+};
+
+main().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import * as baileys from "@whiskeysockets/baileys";
 import discordJs from "discord.js";
-import { createDiscordClient } from "./clientFactories.js";
 import {
 	getChatHostChannelId,
 	getChatTargetChannelId,
 	isThreadChatLink,
 } from "./chatLinks.js";
+import { createDiscordClient } from "./clientFactories.js";
 import groupMetadataCache from "./groupMetadataCache.js";
 import messageStore from "./messageStore.js";
 import {
@@ -190,7 +190,8 @@ const resolveManualLinkTarget = async (channel) => {
 
 	const parentId = channel.parentId || channel.parent?.id;
 	const parentChannel =
-		channel.parent || (parentId ? await utils.discord.getChannel(parentId) : null);
+		channel.parent ||
+		(parentId ? await utils.discord.getChannel(parentId) : null);
 	if (!parentChannel || !ForumChannelTypes.includes(parentChannel.type)) {
 		return {
 			ok: false,
@@ -219,7 +220,8 @@ const buildChatLinkFromWebhook = (webhook, { threadId = null } = {}) => ({
 const isWebhookSharedAcrossChats = (webhookId, exceptJid = null) =>
 	Object.entries(state.chats || {}).some(
 		([jid, chatLink]) =>
-			jid !== exceptJid && String(chatLink?.id || "") === String(webhookId || ""),
+			jid !== exceptJid &&
+			String(chatLink?.id || "") === String(webhookId || ""),
 	);
 
 const requestSafeRestart = async (
@@ -3701,7 +3703,8 @@ const commandHandlers = {
 		},
 	},
 	defaultchat: {
-		description: "Choose whether new WhatsApp chats are created as channels or threads.",
+		description:
+			"Choose whether new WhatsApp chats are created as channels or threads.",
 		options: [
 			{
 				name: "mode",
@@ -3730,11 +3733,13 @@ const commandHandlers = {
 		},
 	},
 	threadnotifications: {
-		description: "Toggle the one-time notification post when WA2DC creates a new WhatsApp thread.",
+		description:
+			"Toggle the one-time notification post when WA2DC creates a new WhatsApp thread.",
 		options: [
 			{
 				name: "enabled",
-				description: "Whether new WA-created threads should ping configured users/roles.",
+				description:
+					"Whether new WA-created threads should ping configured users/roles.",
 				type: ApplicationCommandOptionTypes.BOOLEAN,
 				required: true,
 			},
@@ -3754,7 +3759,8 @@ const commandHandlers = {
 		options: [
 			{
 				name: "action",
-				description: "Add, remove, or list configured thread-notification targets.",
+				description:
+					"Add, remove, or list configured thread-notification targets.",
 				type: ApplicationCommandOptionTypes.STRING,
 				required: true,
 				choices: [
@@ -3782,8 +3788,12 @@ const commandHandlers = {
 			const role = ctx.getRoleOption("role");
 
 			if (action === "list") {
-				const roleTargets = [...new Set(state.settings.ThreadNotificationRoles || [])];
-				const userTargets = [...new Set(state.settings.ThreadNotificationUsers || [])];
+				const roleTargets = [
+					...new Set(state.settings.ThreadNotificationRoles || []),
+				];
+				const userTargets = [
+					...new Set(state.settings.ThreadNotificationUsers || []),
+				];
 				await ctx.reply(
 					[
 						`Thread notifications: ${state.settings.ThreadNotificationsEnabled ? "enabled" : "disabled"}`,
@@ -3799,9 +3809,7 @@ const commandHandlers = {
 				return;
 			}
 			if (Boolean(user) === Boolean(role)) {
-				await ctx.reply(
-					"Choose exactly one target: either `user` or `role`.",
-				);
+				await ctx.reply("Choose exactly one target: either `user` or `role`.");
 				return;
 			}
 
@@ -3830,10 +3838,14 @@ const commandHandlers = {
 			}
 			if (isRoleTarget) {
 				state.settings.ThreadNotificationRoles =
-					state.settings.ThreadNotificationRoles.filter((id) => id !== targetId);
+					state.settings.ThreadNotificationRoles.filter(
+						(id) => id !== targetId,
+					);
 			} else {
 				state.settings.ThreadNotificationUsers =
-					state.settings.ThreadNotificationUsers.filter((id) => id !== targetId);
+					state.settings.ThreadNotificationUsers.filter(
+						(id) => id !== targetId,
+					);
 			}
 			await storage.saveSettings().catch(() => {});
 			await ctx.reply(`Removed ${targetLabel} from thread notifications.`);
@@ -3976,8 +3988,9 @@ const commandHandlers = {
 				!isWebhookSharedAcrossChats(previousChat.id, normalizedJid)
 			) {
 				try {
-					const previousChannel =
-						await utils.discord.getChannel(previousHostChannelId);
+					const previousChannel = await utils.discord.getChannel(
+						previousHostChannelId,
+					);
 					const previousWebhooks = await previousChannel?.fetchWebhooks();
 					const previousWebhook =
 						previousWebhooks?.get(previousChat.id) ||
@@ -5526,7 +5539,9 @@ const handleInteractionCommand = async (interaction, commandName) => {
 const isUnknownInteractionError = (err) =>
 	Number(err?.code) === 10062 ||
 	Number(err?.rawError?.code) === 10062 ||
-	String(err?.message || "").toLowerCase().includes("unknown interaction");
+	String(err?.message || "")
+		.toLowerCase()
+		.includes("unknown interaction");
 
 const handleInteractionCommandFailure = async ({
 	interaction,
@@ -5593,7 +5608,8 @@ client.on("interactionCreate", async (interaction) => {
 	} catch (err) {
 		await handleInteractionCommandFailure({
 			interaction,
-			commandName: interaction.commandName?.toLowerCase() || interaction.customId,
+			commandName:
+				interaction.commandName?.toLowerCase() || interaction.customId,
 			err,
 		});
 	}

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,8 +4,8 @@ import path from "node:path";
 import readline from "node:readline";
 import { BufferJSON } from "@whiskeysockets/baileys";
 import discordJs from "discord.js";
-import { createDiscordClient } from "./clientFactories.js";
 import { normalizeChatLinks } from "./chatLinks.js";
+import { createDiscordClient } from "./clientFactories.js";
 import sqliteStore from "./persistence/sqliteStore.js";
 import state from "./state.js";
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2552,8 +2552,11 @@ const normalizeDiscordId = (value) => {
 	const trimmed = String(value).trim();
 	return trimmed ? trimmed : null;
 };
-const uniqueDiscordIds = (value = []) =>
-	[...new Set((Array.isArray(value) ? value : []).map(normalizeDiscordId).filter(Boolean))];
+const uniqueDiscordIds = (value = []) => [
+	...new Set(
+		(Array.isArray(value) ? value : []).map(normalizeDiscordId).filter(Boolean),
+	),
+];
 const getManagedThreadHostName = (index = 0) =>
 	index <= 0
 		? MANAGED_THREAD_HOST_BASE_NAME
@@ -2587,7 +2590,9 @@ const attachWebhookChatMetadata = (webhook, chatLink = {}) => {
 	if (!webhook) return webhook;
 	webhook.wa2dcThreadId = normalizeDiscordId(chatLink?.threadId);
 	webhook.wa2dcTargetChannelId =
-		getChatTargetChannelId(chatLink) || webhook.wa2dcThreadId || webhook.channelId;
+		getChatTargetChannelId(chatLink) ||
+		webhook.wa2dcThreadId ||
+		webhook.channelId;
 	return webhook;
 };
 const withThreadIdForChat = (payload, jid) => {
@@ -2615,9 +2620,10 @@ const discord = {
 		return this.channelIdToJids(channelId)[0] || null;
 	},
 	hostChannelIdToJids(channelId) {
-		return Object.keys(state.chats).filter((key) =>
-			isThreadChatLink(state.chats[key]) &&
-			chatUsesHostChannelId(state.chats[key], channelId),
+		return Object.keys(state.chats).filter(
+			(key) =>
+				isThreadChatLink(state.chats[key]) &&
+				chatUsesHostChannelId(state.chats[key], channelId),
 		);
 	},
 	getChatLink(jid) {
@@ -2632,7 +2638,10 @@ const discord = {
 		return targetChannelId ? `<#${targetChannelId}>` : null;
 	},
 	isManagedThreadHostChannel(channel = {}) {
-		return isForumChannelType(channel?.type) && isManagedThreadHostName(channel?.name);
+		return (
+			isForumChannelType(channel?.type) &&
+			isManagedThreadHostName(channel?.name)
+		);
 	},
 	partitionText(text) {
 		return text.match(/(.|[\r\n]){1,2000}/g) || [];
@@ -2936,7 +2945,10 @@ const discord = {
 	},
 	buildManagedThreadStarterPayload(
 		jid,
-		{ restored = false, notifyTargets = state.settings.ThreadNotificationsEnabled } = {},
+		{
+			restored = false,
+			notifyTargets = state.settings.ThreadNotificationsEnabled,
+		} = {},
 	) {
 		const name = whatsapp.jidToName(jid);
 		const roleIds = uniqueDiscordIds(state.settings?.ThreadNotificationRoles);
@@ -2966,7 +2978,9 @@ const discord = {
 			...(allowedMentions ? { allowedMentions } : {}),
 		};
 	},
-	async getOrCreateManagedThreadHostChannel({ preferredHostChannelId = null } = {}) {
+	async getOrCreateManagedThreadHostChannel({
+		preferredHostChannelId = null,
+	} = {}) {
 		const guild = await this.getGuild();
 		if (!guild) return null;
 		await guild.channels.fetch();
@@ -2983,7 +2997,10 @@ const discord = {
 			if (!isThreadChatLink(chatLink)) return;
 			const hostChannelId = getChatHostChannelId(chatLink);
 			if (!hostChannelId) return;
-			threadCounts.set(hostChannelId, (threadCounts.get(hostChannelId) || 0) + 1);
+			threadCounts.set(
+				hostChannelId,
+				(threadCounts.get(hostChannelId) || 0) + 1,
+			);
 		});
 
 		const managedHosts = [...guild.channels.cache.values()]
@@ -3015,7 +3032,11 @@ const discord = {
 	},
 	async createManagedThreadLink(
 		jid,
-		{ restored = false, notifyTargets = state.settings.ThreadNotificationsEnabled, preferredHostChannelId = null } = {},
+		{
+			restored = false,
+			notifyTargets = state.settings.ThreadNotificationsEnabled,
+			preferredHostChannelId = null,
+		} = {},
 	) {
 		const hostChannel = await this.getOrCreateManagedThreadHostChannel({
 			preferredHostChannelId,
@@ -3069,7 +3090,10 @@ const discord = {
 			...created.chatLink,
 		};
 		delete state.goccRuns[normalizedJid];
-		return attachWebhookChatMetadata(created.webhook, state.chats[normalizedJid]);
+		return attachWebhookChatMetadata(
+			created.webhook,
+			state.chats[normalizedJid],
+		);
 	},
 	_unfinishedGoccCalls: 0,
 	async getOrCreateChannel(jid) {
@@ -3129,10 +3153,7 @@ const discord = {
 				});
 				const webhook = await this.getOrCreateOwnedWebhook(channel);
 				state.chats[normalizedJid] = buildStoredChatLink(webhook);
-				return attachWebhookChatMetadata(
-					webhook,
-					state.chats[normalizedJid],
-				);
+				return attachWebhookChatMetadata(webhook, state.chats[normalizedJid]);
 			} finally {
 				this._unfinishedGoccCalls--;
 			}
@@ -3196,7 +3217,10 @@ const discord = {
 				return null;
 			}
 			const refreshedWebhook = await this.getOrCreateOwnedWebhook(channel);
-			state.chats[normalizedJid] = buildStoredChatLink(refreshedWebhook, chatInfo);
+			state.chats[normalizedJid] = buildStoredChatLink(
+				refreshedWebhook,
+				chatInfo,
+			);
 			return attachWebhookChatMetadata(
 				refreshedWebhook,
 				state.chats[normalizedJid],
@@ -3615,7 +3639,9 @@ const discord = {
 
 		for (const [jid, chatLink] of Object.entries(state.chats)) {
 			try {
-				const channel = await guild.channels.fetch(getChatTargetChannelId(chatLink));
+				const channel = await guild.channels.fetch(
+					getChatTargetChannelId(chatLink),
+				);
 				await channel.edit({
 					name: whatsapp.jidToName(jid),
 				});

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -14,8 +14,8 @@ import {
 	getKeyAuthor,
 } from "@whiskeysockets/baileys/lib/Utils/generics.js";
 import { decryptPollVote } from "@whiskeysockets/baileys/lib/Utils/process-message.js";
-import { getChatTargetChannelId } from "./chatLinks.js";
 import useSQLiteAuthState from "./auth/sqliteAuthState.js";
+import { getChatTargetChannelId } from "./chatLinks.js";
 import { createWhatsAppClient, getBaileysVersion } from "./clientFactories.js";
 import groupMetadataCache from "./groupMetadataCache.js";
 import { createGroupRefreshScheduler } from "./groupMetadataRefresh.js";
@@ -2915,7 +2915,7 @@ const connectToWhatsApp = async (retry = 1) => {
 
 			return stored.message || stored;
 		},
-		browser: Browsers.android('13'),
+		browser: Browsers.android("13"),
 	});
 	client.contacts = state.contacts;
 	patchSendMessageForLinkPreviews(client);

--- a/tests/baileysAndroidBrowserPatch.test.js
+++ b/tests/baileysAndroidBrowserPatch.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Browsers, proto } from "@whiskeysockets/baileys";
+import { generateLoginNode } from "@whiskeysockets/baileys/lib/Utils/validate-connection.js";
+
+test("Baileys rc10 carries WA2DC Android browser patch", () => {
+	assert.equal(typeof Browsers.android, "function");
+	assert.deepEqual(Browsers.android("13"), ["13", "Android", ""]);
+
+	const payload = generateLoginNode("12345:1@s.whatsapp.net", {
+		browser: Browsers.android("13"),
+		countryCode: "US",
+		version: [2, 3000, 0],
+	});
+	const userAgent = proto.ClientPayload.toObject(payload).userAgent;
+
+	assert.equal(
+		userAgent.platform,
+		proto.ClientPayload.UserAgent.Platform.ANDROID,
+	);
+});


### PR DESCRIPTION
- Updated `@whiskeysockets/baileys` from the `android-browser` GitHub branch to published `7.0.0-rc10`
- Added a postinstall patch script for the upstream Android browser behavior needed by WA2DC
- Added a regression test covering `Browsers.android("13")` and Android login payload generation
- Updated Baileys 7 migration docs for rc10 and the local patch
- Bumped `jsdom` to `29.1.0`
- Bumped `@biomejs/biome` to `2.4.13`
- Applied Biome 2.4.13 formatting/import-order updates