### PR TITLE
Map group-wide mentions between WhatsApp and Discord

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -209,7 +209,7 @@ Usage: `/hidephonenumbers enabled:<true|false>`
 WA2DC can optionally translate WhatsApp @mentions into Discord user mentions, if you link a WhatsApp contact to a Discord user.
 This only works for **real WhatsApp mentions** (select the person from WhatsApp’s mention picker); manually typing `@name` without selecting won’t include mention metadata and can’t be translated reliably.
 WhatsApp group-wide `@all` mentions are mirrored as Discord `@everyone` mentions when WhatsApp includes mention-all metadata; plain typed `@all` text is left unchanged.
-If a WhatsApp contact is linked, WA2DC will also translate **Discord user @mentions** into **WhatsApp mentions** when forwarding messages from Discord to WhatsApp (you must use a real Discord mention — select the user from autocomplete so Discord inserts a `<@...>` mention).
+If a WhatsApp contact is linked, WA2DC will also translate **Discord user @mentions** into **WhatsApp mentions** when forwarding messages from Discord to WhatsApp (you must use a real Discord mention — select the user from autocomplete so Discord inserts a `<@...>` mention). In WhatsApp group chats, real Discord `@everyone` / `@here` mentions are forwarded as WhatsApp `@all`; plain typed text is left unchanged.
 
 ### `/linkmention`
 Link a WhatsApp contact to a Discord user so future WhatsApp @mentions ping them in Discord.  

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -208,6 +208,7 @@ Usage: `/hidephonenumbers enabled:<true|false>`
 
 WA2DC can optionally translate WhatsApp @mentions into Discord user mentions, if you link a WhatsApp contact to a Discord user.
 This only works for **real WhatsApp mentions** (select the person from WhatsApp’s mention picker); manually typing `@name` without selecting won’t include mention metadata and can’t be translated reliably.
+WhatsApp group-wide `@all` mentions are mirrored as Discord `@everyone` mentions when WhatsApp includes mention-all metadata; plain typed `@all` text is left unchanged.
 If a WhatsApp contact is linked, WA2DC will also translate **Discord user @mentions** into **WhatsApp mentions** when forwarding messages from Discord to WhatsApp (you must use a real Discord mention — select the user from autocomplete so Discord inserts a `<@...>` mention).
 
 ### `/linkmention`

--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -32,6 +32,7 @@ Respect transport constraints when emitting output:
 - 2000-character message limit
 - use `utils.discord.partitionText(...)` for long responses
 - only enable Discord `@everyone` parsing for WhatsApp `@all` messages when WhatsApp includes mention-all metadata (`contextInfo.nonJidMentions`)
+- only set WhatsApp `mentionAll` for Discord `@everyone` / `@here` when Discord includes real everyone-mention metadata and the target is a WhatsApp group chat
 - respect file-size gating (for example `DiscordFileSizeLimit`)
 - keep WhatsApp-backed Discord attachment uploads bounded during media bursts; honor `state.settings.WhatsAppDiscordMediaBurstSize` and do not exceed Discord's 10-file upload limit
 - treat transient Discord upload transport failures from both Undici and Node HTTP/2 stream errors as retryable so WhatsApp-backed media bursts can recover or emit a fallback notice instead of dropping silently

--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -1,7 +1,7 @@
 # Bridge Constraints
 
 > Owner: WA2DC maintainers
-> Last reviewed: 2026-04-06
+> Last reviewed: 2026-05-07
 > Scope: Message-routing and identity constraints that prevent regressions.
 
 ## Echo-loop prevention
@@ -31,6 +31,7 @@ Respect transport constraints when emitting output:
 
 - 2000-character message limit
 - use `utils.discord.partitionText(...)` for long responses
+- only enable Discord `@everyone` parsing for WhatsApp `@all` messages when WhatsApp includes mention-all metadata (`contextInfo.nonJidMentions`)
 - respect file-size gating (for example `DiscordFileSizeLimit`)
 - keep WhatsApp-backed Discord attachment uploads bounded during media bursts; honor `state.settings.WhatsAppDiscordMediaBurstSize` and do not exceed Discord's 10-file upload limit
 - treat transient Discord upload transport failures from both Undici and Node HTTP/2 stream errors as retryable so WhatsApp-backed media bursts can recover or emit a fallback notice instead of dropping silently

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -981,9 +981,11 @@ const sendWhatsappMessage = async (
 			mentionIdsRaw.map((id) => String(id)).filter((id) => /^\d+$/.test(id)),
 		),
 	];
-	const allowedMentions = mentionIds.length
-		? { parse: [], users: mentionIds }
-		: undefined;
+	const mentionEveryone = message?.discordMentionEveryone === true;
+	const allowedMentions = {
+		parse: mentionEveryone ? ["everyone"] : [],
+		...(mentionIds.length ? { users: mentionIds } : {}),
+	};
 	const content = utils.discord.convertWhatsappFormatting(message.content);
 	const quoteContent = message.quote
 		? utils.discord.convertWhatsappFormatting(message.quote.content)

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,7 @@ const buildUnicodeMentionRegex = (token) =>
 	new RegExp(`@${escapeRegex(token)}(?=$|\\s|[\\p{P}\\p{S}])`, "giu");
 const buildWordBoundaryMentionRegex = (token) =>
 	new RegExp(`@${escapeRegex(token)}(?=\\W|$)`, "g");
+const WHATSAPP_MENTION_ALL_REGEX = /@all(?=$|\s|[\p{P}\p{S}])/giu;
 const asLower = (value) => String(value || "").toLowerCase();
 const includesHint = (text, hints) =>
 	hints.some((hint) => text.includes(asLower(hint)));
@@ -5022,11 +5023,12 @@ const whatsapp = {
 	async getContent(msg, nMsgType, msgType, { mentionTarget = "name" } = {}) {
 		let content = "";
 		const discordMentions = new Set();
+		let discordMentionEveryone = false;
 		if (msgType === "viewOnceMessageV2") {
 			content += "View once message:\n";
 		}
 		if (msg == null) {
-			return { content, discordMentions: [] };
+			return { content, discordMentions: [], discordMentionEveryone };
 		}
 		switch (nMsgType) {
 			case "conversation":
@@ -5070,6 +5072,20 @@ const whatsapp = {
 		const mentions = contextInfo?.mentionedJid || [];
 		const links = state.settings?.WhatsAppDiscordMentionLinks;
 		const hasLinks = links && typeof links === "object";
+		const nonJidMentionCount = Number(contextInfo?.nonJidMentions || 0);
+		const hasWhatsAppMentionAll =
+			Number.isFinite(nonJidMentionCount) && nonJidMentionCount > 0;
+
+		if (mentionTarget === "discord" && hasWhatsAppMentionAll) {
+			const nextContent = content.replace(
+				WHATSAPP_MENTION_ALL_REGEX,
+				"@everyone",
+			);
+			if (nextContent !== content) {
+				content = nextContent;
+				discordMentionEveryone = true;
+			}
+		}
 
 		const resolveLinkedDiscordUserId = async (jid) => {
 			if (!hasLinks) return null;
@@ -5315,7 +5331,11 @@ const whatsapp = {
 			content = content ? `${content} ${suffix}` : suffix;
 		}
 
-		return { content, discordMentions: [...discordMentions] };
+		return {
+			content,
+			discordMentions: [...discordMentions],
+			discordMentionEveryone,
+		};
 	},
 	updateContacts(rawContacts) {
 		const contacts = rawContacts.chats || rawContacts.contacts || rawContacts;

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -3240,12 +3240,10 @@ const connectToWhatsApp = async (retry = 1) => {
 					rawMessage,
 					messageType,
 				);
-				const { content, discordMentions } = await utils.whatsapp.getContent(
-					message,
-					nMsgType,
-					messageType,
-					{ mentionTarget: "discord" },
-				);
+				const { content, discordMentions, discordMentionEveryone } =
+					await utils.whatsapp.getContent(message, nMsgType, messageType, {
+						mentionTarget: "discord",
+					});
 				state.dcClient.emit("whatsappMessage", {
 					id: utils.whatsapp.getId(rawMessage),
 					name: await utils.whatsapp.getSenderName(rawMessage),
@@ -3261,6 +3259,7 @@ const connectToWhatsApp = async (retry = 1) => {
 					),
 					isEdit: messageType === "editedMessage",
 					discordMentions,
+					discordMentionEveryone,
 				});
 				const ts = utils.whatsapp.getTimestamp(rawMessage);
 				if (ts > state.startTime) state.startTime = ts;

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -941,6 +941,7 @@ const sendMediaAlbumToWhatsApp = async ({
 	contents,
 	captionText = "",
 	mentionJids = [],
+	mentionAll = false,
 	quoted = null,
 } = {}) => {
 	const relayBaseOptions = buildAlbumRelayOptions({
@@ -1011,6 +1012,9 @@ const sendMediaAlbumToWhatsApp = async ({
 				}
 				if (mentionJids.length) {
 					payload.contextInfo.mentionedJid = mentionJids;
+				}
+				if (mentionAll) {
+					payload.contextInfo.nonJidMentions = 1;
 				}
 			}
 			const childMessage = generateWAMessageFromContent(
@@ -1875,6 +1879,8 @@ const replaceLiteralMentionTokens = (text, replacements = []) => {
 
 const DISCORD_USER_MENTION_REGEX = /<@!?(\d+)>/g;
 const DISCORD_ROLE_MENTION_REGEX = /<@&(\d+)>/g;
+const DISCORD_EVERYONE_MENTION_REGEX =
+	/@(everyone|here)(?=$|\s|[\p{P}\p{S}])/giu;
 const DISCORD_REPLY_PREFIX_REGEX = /^(<@!?\d+>|@\S+)\s*/;
 const DISCORD_REPLY_FALLBACK_MAX_CHARS = 160;
 const DISCORD_MESSAGE_TYPE_REPLY = 19;
@@ -2090,6 +2096,25 @@ const normalizeMentionJidsForChat = async (jid, mentionJids = []) => [
 	),
 ];
 
+const resolveDiscordEveryoneMentionForWhatsApp = ({ message, text, jid }) => {
+	const canMentionAll =
+		typeof jid === "string" &&
+		jid.endsWith("@g.us") &&
+		message?.mentions?.everyone === true;
+	if (!canMentionAll) return { text, mentionAll: false };
+
+	let replaced = false;
+	const sourceText = typeof text === "string" ? text : "";
+	let nextText = sourceText.replace(DISCORD_EVERYONE_MENTION_REGEX, () => {
+		replaced = true;
+		return "@all";
+	});
+	if (!replaced) {
+		nextText = nextText ? `@all ${nextText}` : "@all";
+	}
+	return { text: nextText, mentionAll: true };
+};
+
 const resolveDiscordTextMentionsForWhatsApp = async ({
 	message,
 	text,
@@ -2107,10 +2132,16 @@ const resolveDiscordTextMentionsForWhatsApp = async ({
 					{ chatJid: jid },
 				)
 			: { text, mentionJids: [] };
-	const updatedText = replaceLiteralMentionTokens(
+	let updatedText = replaceLiteralMentionTokens(
 		linkedMentions.text ?? text,
 		fallbackReplacements,
 	);
+	const everyoneMention = resolveDiscordEveryoneMentionForWhatsApp({
+		message,
+		text: updatedText,
+		jid,
+	});
+	updatedText = everyoneMention.text;
 	const mentionJidsRaw = [
 		...new Set([
 			...(Array.isArray(linkedMentions.mentionJids)
@@ -2120,7 +2151,11 @@ const resolveDiscordTextMentionsForWhatsApp = async ({
 		]),
 	];
 	const mentionJids = await normalizeMentionJidsForChat(jid, mentionJidsRaw);
-	return { text: updatedText, mentionJids };
+	return {
+		text: updatedText,
+		mentionJids,
+		mentionAll: everyoneMention.mentionAll,
+	};
 };
 
 const handlePollUpdateMessage = async (client, rawMessage) => {
@@ -3908,6 +3943,7 @@ const connectToWhatsApp = async (retry = 1) => {
 		});
 		text = mentionResolution.text;
 		const mentionJids = mentionResolution.mentionJids;
+		const mentionAll = mentionResolution.mentionAll;
 		const ensureNewsletterReplyFallbackContext = async () => {
 			if (!useNewsletterSpecialFlow || !hasReplyReference) return "";
 			if (newsletterReplyFallbackContext) return newsletterReplyFallbackContext;
@@ -4213,6 +4249,7 @@ const connectToWhatsApp = async (retry = 1) => {
 						contents: batch.map((entry) => entry.content),
 						captionText: batchIndex === 0 ? attachmentCaptionText : "",
 						mentionJids: batchIndex === 0 ? mentionJids : [],
+						mentionAll: batchIndex === 0 ? mentionAll : false,
 						quoted: batchIndex === 0 ? options?.quoted : undefined,
 					});
 					if (albumResult?.error) {
@@ -4264,6 +4301,9 @@ const connectToWhatsApp = async (retry = 1) => {
 				if (!newsletterChat && mentionJids.length) {
 					standaloneTextPayload.mentions = mentionJids;
 				}
+				if (mentionAll) {
+					standaloneTextPayload.mentionAll = true;
+				}
 				await sendTrackedMessage(standaloneTextPayload, options, {
 					ackContext: "Sticker companion text send",
 					forceNewsletterAck: newsletterChat,
@@ -4291,6 +4331,9 @@ const connectToWhatsApp = async (retry = 1) => {
 						mentionJids.length
 					) {
 						doc.mentions = mentionJids;
+					}
+					if (!sentStandaloneStickerText && mentionAll) {
+						doc.mentionAll = true;
 					}
 				}
 				try {
@@ -4375,6 +4418,9 @@ const connectToWhatsApp = async (retry = 1) => {
 		const content = { text: finalText };
 		if (!newsletterChat && mentionJids.length) {
 			content.mentions = mentionJids;
+		}
+		if (mentionAll) {
+			content.mentionAll = true;
 		}
 		let preview = null;
 		if (!newsletterChat) {
@@ -4544,6 +4590,7 @@ const connectToWhatsApp = async (retry = 1) => {
 		});
 		text = mentionResolution.text;
 		const editMentions = mentionResolution.mentionJids;
+		const editMentionAll = mentionResolution.mentionAll;
 		const editOptions = buildSendOptionsForJid(targetJid);
 		const sendEditWithKey = async (editKey, mode = "default") => {
 			if (newsletterChat) {
@@ -4571,6 +4618,7 @@ const connectToWhatsApp = async (retry = 1) => {
 					...(!newsletterChat && editMentions.length
 						? { mentions: editMentions }
 						: {}),
+					...(editMentionAll ? { mentionAll: true } : {}),
 				},
 				editOptions,
 			);

--- a/tests/discordBridge.test.js
+++ b/tests/discordBridge.test.js
@@ -403,6 +403,113 @@ test("WhatsApp sender platform suffix appends to mirrored Discord messages", asy
 	}
 });
 
+test("WhatsApp @all payload allows Discord @everyone mention", async () => {
+	const originalDiscordUtils = {
+		getGuild: utils.discord.getGuild,
+		getControlChannel: utils.discord.getControlChannel,
+		getOrCreateChannel: utils.discord.getOrCreateChannel,
+		safeWebhookSend: utils.discord.safeWebhookSend,
+	};
+	const originalSettings = {
+		Token: state.settings.Token,
+		GuildID: state.settings.GuildID,
+		oneWay: state.settings.oneWay,
+	};
+	const originalLastMessages = state.lastMessages;
+	const originalDcClient = state.dcClient;
+
+	try {
+		state.settings.Token = "TEST_TOKEN";
+		state.settings.GuildID = "guild";
+		state.settings.oneWay = 0b11;
+		state.lastMessages = {};
+
+		utils.discord.getGuild = async () => ({
+			commands: { set: async () => {} },
+		});
+		utils.discord.getControlChannel = async () => ({ send: async () => {} });
+		utils.discord.getOrCreateChannel = async () => ({
+			id: "hook-1",
+			token: "token",
+			channel: { type: "GUILD_TEXT" },
+		});
+
+		const sent = [];
+		utils.discord.safeWebhookSend = async (_webhook, args) => {
+			sent.push(args);
+			return { id: `dc-${sent.length}`, channel: { type: "GUILD_TEXT" } };
+		};
+
+		class FakeDiscordClient extends EventEmitter {
+			constructor() {
+				super();
+				this.user = { id: "bot-1" };
+			}
+
+			async login() {
+				queueMicrotask(() => this.emit("ready"));
+				return this;
+			}
+		}
+
+		const fakeClient = new FakeDiscordClient();
+		setClientFactoryOverrides({ createDiscordClient: () => fakeClient });
+		const discordHandler = await importDiscordHandler("wa-mention-all");
+		state.dcClient = await discordHandler.start();
+
+		fakeClient.emit("whatsappMessage", {
+			id: "wa-mention-all",
+			name: "Tester",
+			content: "hello @everyone",
+			channelJid: "jid@s.whatsapp.net",
+			file: null,
+			quote: null,
+			profilePic: null,
+			isGroup: false,
+			isForwarded: false,
+			isEdit: false,
+			discordMentionEveryone: true,
+		});
+		await delay(0);
+
+		assert.equal(sent.length, 1);
+		assert.equal(sent[0]?.content, "hello @everyone");
+		assert.deepEqual(sent[0]?.allowedMentions, { parse: ["everyone"] });
+
+		fakeClient.emit("whatsappMessage", {
+			id: "wa-manual-everyone",
+			name: "Tester",
+			content: "manual @everyone",
+			channelJid: "jid@s.whatsapp.net",
+			file: null,
+			quote: null,
+			profilePic: null,
+			isGroup: false,
+			isForwarded: false,
+			isEdit: false,
+			discordMentionEveryone: false,
+		});
+		await delay(0);
+
+		assert.equal(sent.length, 2);
+		assert.equal(sent[1]?.content, "manual @everyone");
+		assert.deepEqual(sent[1]?.allowedMentions, { parse: [] });
+	} finally {
+		utils.discord.getGuild = originalDiscordUtils.getGuild;
+		utils.discord.getControlChannel = originalDiscordUtils.getControlChannel;
+		utils.discord.getOrCreateChannel = originalDiscordUtils.getOrCreateChannel;
+		utils.discord.safeWebhookSend = originalDiscordUtils.safeWebhookSend;
+
+		state.settings.Token = originalSettings.Token;
+		state.settings.GuildID = originalSettings.GuildID;
+		state.settings.oneWay = originalSettings.oneWay;
+
+		state.lastMessages = originalLastMessages;
+		state.dcClient = originalDcClient;
+		resetClientFactoryOverrides();
+	}
+});
+
 test("Discord messageDelete emits discordDelete for bridged messages", async () => {
 	const originalDiscordUtils = {
 		getGuild: utils.discord.getGuild,

--- a/tests/mentionLinks.test.js
+++ b/tests/mentionLinks.test.js
@@ -499,3 +499,39 @@ test("Discord mentions prefer PN JIDs when both PN and LID links exist", async (
 		state.settings.WhatsAppDiscordMentionLinks = originalLinks;
 	}
 });
+
+test("WhatsApp mention-all metadata converts @all to Discord @everyone", async () => {
+	const msg = {
+		text: "Team update @all",
+		contextInfo: { nonJidMentions: 1 },
+	};
+
+	const result = await utils.whatsapp.getContent(
+		msg,
+		"extendedTextMessage",
+		"extendedTextMessage",
+		{ mentionTarget: "discord" },
+	);
+
+	assert.equal(result.content, "Team update @everyone");
+	assert.equal(result.discordMentionEveryone, true);
+	assert.deepEqual(result.discordMentions, []);
+});
+
+test("Plain @all text without WhatsApp mention-all metadata is not promoted", async () => {
+	const msg = {
+		text: "Team update @all",
+		contextInfo: {},
+	};
+
+	const result = await utils.whatsapp.getContent(
+		msg,
+		"extendedTextMessage",
+		"extendedTextMessage",
+		{ mentionTarget: "discord" },
+	);
+
+	assert.equal(result.content, "Team update @all");
+	assert.equal(result.discordMentionEveryone, false);
+	assert.deepEqual(result.discordMentions, []);
+});

--- a/tests/whatsappBridge.test.js
+++ b/tests/whatsappBridge.test.js
@@ -1310,6 +1310,140 @@ test("Discord raw user and role mentions are converted before forwarding to What
 	}
 });
 
+test("Discord everyone and here mentions become WhatsApp @all in group chats", async () => {
+	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
+	try {
+		harness.fakeClient.ev.emit("discordMessage", {
+			jid: "123456789@g.us",
+			message: {
+				id: "dc-everyone-msg",
+				content: "Team @everyone",
+				cleanContent: "Team @everyone",
+				webhookId: null,
+				author: { username: "BridgeUser" },
+				member: { displayName: "BridgeUser" },
+				channel: { send: async () => {} },
+				attachments: new Map(),
+				stickers: new Map(),
+				embeds: [],
+				mentions: {
+					everyone: true,
+					users: new Map(),
+					members: new Map(),
+					roles: new Map(),
+				},
+			},
+		});
+		await delay(0);
+
+		assert.equal(harness.fakeClient.sendCalls[0]?.content?.text, "Team @all");
+		assert.equal(harness.fakeClient.sendCalls[0]?.content?.mentionAll, true);
+
+		harness.fakeClient.ev.emit("discordMessage", {
+			jid: "123456789@g.us",
+			message: {
+				id: "dc-here-msg",
+				content: "Team @here",
+				cleanContent: "Team @here",
+				webhookId: null,
+				author: { username: "BridgeUser" },
+				member: { displayName: "BridgeUser" },
+				channel: { send: async () => {} },
+				attachments: new Map(),
+				stickers: new Map(),
+				embeds: [],
+				mentions: {
+					everyone: true,
+					users: new Map(),
+					members: new Map(),
+					roles: new Map(),
+				},
+			},
+		});
+		await delay(0);
+
+		assert.equal(harness.fakeClient.sendCalls[1]?.content?.text, "Team @all");
+		assert.equal(harness.fakeClient.sendCalls[1]?.content?.mentionAll, true);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("Plain Discord @everyone text is not promoted to WhatsApp @all", async () => {
+	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
+	try {
+		harness.fakeClient.ev.emit("discordMessage", {
+			jid: "123456789@g.us",
+			message: {
+				id: "dc-manual-everyone-msg",
+				content: "Manual @everyone",
+				cleanContent: "Manual @everyone",
+				webhookId: null,
+				author: { username: "BridgeUser" },
+				member: { displayName: "BridgeUser" },
+				channel: { send: async () => {} },
+				attachments: new Map(),
+				stickers: new Map(),
+				embeds: [],
+				mentions: {
+					everyone: false,
+					users: new Map(),
+					members: new Map(),
+					roles: new Map(),
+				},
+			},
+		});
+		await delay(0);
+
+		assert.equal(
+			harness.fakeClient.sendCalls[0]?.content?.text,
+			"Manual @everyone",
+		);
+		assert.equal(
+			harness.fakeClient.sendCalls[0]?.content?.mentionAll,
+			undefined,
+		);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("Discord edited everyone mentions keep WhatsApp mentionAll metadata", async () => {
+	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
+	try {
+		state.lastMessages["dc-edit-everyone"] = "wa-edit-everyone";
+
+		harness.fakeClient.ev.emit("discordEdit", {
+			jid: "123456789@g.us",
+			message: {
+				id: "dc-edit-everyone",
+				content: "Edited @everyone",
+				cleanContent: "Edited @everyone",
+				webhookId: null,
+				author: { username: "BridgeUser" },
+				member: { displayName: "BridgeUser" },
+				channel: { send: async () => {} },
+				mentions: {
+					everyone: true,
+					users: new Map(),
+					members: new Map(),
+					roles: new Map(),
+				},
+			},
+		});
+		await delay(0);
+
+		assert.equal(harness.fakeClient.sendCalls[0]?.content?.text, "Edited @all");
+		assert.equal(harness.fakeClient.sendCalls[0]?.content?.mentionAll, true);
+		assert.equal(
+			harness.fakeClient.sendCalls[0]?.content?.edit?.id,
+			"wa-edit-everyone",
+		);
+	} finally {
+		harness.cleanup();
+	}
+});
+
 test("Discord embeds are ignored when DiscordEmbedsToWhatsApp is disabled", async () => {
 	const harness = await setupWhatsAppHarness({ oneWay: 0b11 });
 	const originalEmbedSetting = state.settings.DiscordEmbedsToWhatsApp;


### PR DESCRIPTION
- Map WhatsApp group-wide `@all` mentions to Discord `@everyone`
- Map real Discord `@everyone` / `@here` mentions to WhatsApp `@all` in WhatsApp group chats
- Gate both directions on real platform mention metadata so plain typed text does not trigger mass pings
- Thread mention-all handling through normal sends, edits, attachment captions, and media albums
- Update mention docs and bridge constraints