### PR TITLE
Fix WhatsApp RC10 pairing and resync OOM crashes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -382,7 +382,7 @@ Safely save state and restart the bot (requires running via the watchdog runner)
 Usage: `/restart` (control channel only)
 
 ### `/resync`
-Re-sync WhatsApp contacts/groups. Set `rename:true` to rename Discord channels to match WhatsApp subjects.
+Re-sync WhatsApp contacts/groups. Set `rename:true` to rename Discord channels to match WhatsApp subjects. The group refresh uses a lightweight group list query and does not download every group participant roster.
 
 ### `/autosaveinterval`
 Change how often the bot persists state (seconds).  

--- a/docs/dev/runtime-and-layout.md
+++ b/docs/dev/runtime-and-layout.md
@@ -22,7 +22,7 @@ Primary flow:
 WhatsApp startup guardrails:
 
 - `src/whatsappHandler.js` intentionally does not process WhatsApp history-sync payloads beyond push-name updates. The bridge only needs live/offline message delivery, and history payload processing can make Baileys allocate large decoded batches during reconnects after pairing.
-- Do not eagerly call `groupFetchAllParticipating()` on every WhatsApp reconnect. Group metadata is refreshed through live group events and explicit sync commands; all-groups fetches can allocate very large Baileys response structures immediately after pairing.
+- Do not eagerly call `groupFetchAllParticipating()` on WhatsApp reconnect or `/resync`. Group metadata is refreshed through live group events and `/resync` uses a lightweight `@g.us` participating-groups query that does not request every participant roster/description; full all-groups fetches can allocate very large Baileys response structures after pairing.
 - Pass Baileys a bounded logger wrapper instead of the root pino logger. Baileys errors can include bundled `data:text/javascript;base64...` stack traces and binary payloads; keep those summarized so `logs.txt` and `terminal.log` stay useful and do not drive heap pressure.
 
 ## Developer quick start

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -7,7 +7,6 @@ import {
 	isThreadChatLink,
 } from "./chatLinks.js";
 import { createDiscordClient } from "./clientFactories.js";
-import groupMetadataCache from "./groupMetadataCache.js";
 import messageStore from "./messageStore.js";
 import {
 	getNewsletterAckError,
@@ -29,6 +28,7 @@ import { resolveRestartFlagPath } from "./runnerLogic.js";
 import state from "./state.js";
 import storage from "./storage.js";
 import utils from "./utils.js";
+import { resyncWhatsAppContactsAndGroups } from "./whatsappResync.js";
 
 const {
 	ActionRowBuilder,
@@ -4851,16 +4851,8 @@ const commandHandlers = {
 		],
 		async execute(ctx) {
 			await ctx.defer();
-			await state.waClient.authState.keys.set({
-				"app-state-sync-version": { critical_unblock_low: null },
-			});
-			await state.waClient.resyncAppState(["critical_unblock_low"]);
-			const participatingGroups =
-				await state.waClient.groupFetchAllParticipating();
-			groupMetadataCache.prime(participatingGroups);
-			for (const [jid, attributes] of Object.entries(participatingGroups)) {
-				state.waClient.contacts[jid] = attributes.subject;
-			}
+			const { contactCount, groupCount } =
+				await resyncWhatsAppContactsAndGroups(state.waClient);
 			const shouldRename = Boolean(ctx.getBooleanOption("rename"));
 			if (shouldRename) {
 				try {
@@ -4869,7 +4861,9 @@ const commandHandlers = {
 					state.logger?.error(err);
 				}
 			}
-			await ctx.reply("Re-synced!");
+			await ctx.reply(
+				`Re-synced ${contactCount} WhatsApp contacts/groups (${groupCount} participating groups refreshed).`,
+			);
 		},
 	},
 	localdownloads: {

--- a/src/whatsappResync.js
+++ b/src/whatsappResync.js
@@ -1,0 +1,107 @@
+import {
+	getBinaryNodeChild,
+	getBinaryNodeChildren,
+	jidEncode,
+} from "@whiskeysockets/baileys";
+import state from "./state.js";
+import storage from "./storage.js";
+import utils from "./utils.js";
+
+const toGroupJid = (id) => {
+	if (typeof id !== "string" || !id.trim()) return null;
+	const raw = id.trim();
+	const candidate = raw.includes("@") ? raw : jidEncode(raw, "g.us");
+	const normalized = utils.whatsapp.formatJid(candidate);
+	return normalized?.endsWith("@g.us") ? normalized : null;
+};
+
+const groupMetadataFromNode = (groupNode) => {
+	const attrs = groupNode?.attrs || {};
+	const id = toGroupJid(attrs.id);
+	if (!id) return null;
+	return {
+		id,
+		notify: attrs.notify,
+		subject: attrs.subject || attrs.notify || id,
+		subjectOwner: attrs.s_o,
+		subjectOwnerPn: attrs.s_o_pn,
+		subjectTime: attrs.s_t ? Number(attrs.s_t) : undefined,
+		size: attrs.size ? Number(attrs.size) : undefined,
+		creation: attrs.creation ? Number(attrs.creation) : undefined,
+	};
+};
+
+export const fetchParticipatingGroupsLight = async (client) => {
+	if (typeof client?.query !== "function") {
+		return {};
+	}
+
+	const result = await client.query({
+		tag: "iq",
+		attrs: {
+			to: "@g.us",
+			xmlns: "w:g2",
+			type: "get",
+		},
+		content: [{ tag: "participating", attrs: {} }],
+	});
+	const groupsChild = getBinaryNodeChild(result, "groups");
+	const groups = getBinaryNodeChildren(groupsChild, "group");
+	const participatingGroups = {};
+	for (const groupNode of groups) {
+		const metadata = groupMetadataFromNode(groupNode);
+		if (!metadata) continue;
+		participatingGroups[metadata.id] = metadata;
+	}
+	return participatingGroups;
+};
+
+const applyParticipatingGroups = (client, groups = {}) => {
+	let count = 0;
+	for (const [jid, metadata] of Object.entries(groups)) {
+		const normalized = toGroupJid(jid || metadata?.id);
+		if (!normalized || !metadata?.subject) continue;
+		state.contacts[normalized] = metadata.subject;
+		if (client?.contacts) {
+			client.contacts[normalized] = metadata.subject;
+		}
+		count += 1;
+	}
+	return count;
+};
+
+export const resyncWhatsAppContactsAndGroups = async (client) => {
+	if (!client) {
+		throw new Error("WhatsApp client is not connected.");
+	}
+
+	if (
+		client.authState?.keys?.set &&
+		typeof client.resyncAppState === "function"
+	) {
+		await client.authState.keys.set({
+			"app-state-sync-version": { critical_unblock_low: null },
+		});
+		await client.resyncAppState(["critical_unblock_low"]);
+	}
+
+	let groups = {};
+	try {
+		groups = await fetchParticipatingGroupsLight(client);
+	} catch (err) {
+		state.logger?.warn(
+			{ err },
+			"Lightweight participating group resync failed.",
+		);
+	}
+	const groupCount = applyParticipatingGroups(client, groups);
+
+	await storage.save().catch((err) => {
+		state.logger?.warn({ err }, "Failed to persist WhatsApp resync results.");
+	});
+
+	return {
+		contactCount: Object.keys(state.contacts || {}).length,
+		groupCount,
+	};
+};

--- a/tests/whatsappResync.test.js
+++ b/tests/whatsappResync.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import groupMetadataCache from "../src/groupMetadataCache.js";
+import state from "../src/state.js";
+import storage from "../src/storage.js";
+import {
+	fetchParticipatingGroupsLight,
+	resyncWhatsAppContactsAndGroups,
+} from "../src/whatsappResync.js";
+import initIsolatedStorage from "./helpers/initIsolatedStorage.js";
+
+await initIsolatedStorage(import.meta.url);
+
+const restoreObject = (target, snapshot) => {
+	Object.keys(target).forEach((key) => {
+		delete target[key];
+	});
+	Object.assign(target, snapshot);
+};
+
+test("fetchParticipatingGroupsLight queries group list without participants", async () => {
+	let capturedQuery = null;
+	const client = {
+		async query(query) {
+			capturedQuery = query;
+			return {
+				tag: "iq",
+				attrs: {},
+				content: [
+					{
+						tag: "groups",
+						attrs: {},
+						content: [
+							{
+								tag: "group",
+								attrs: {
+									id: "123456789-987654321",
+									subject: "Alpha Group",
+									size: "42",
+								},
+							},
+						],
+					},
+				],
+			};
+		},
+		async groupFetchAllParticipating() {
+			throw new Error("heavy group fetch should not be called");
+		},
+	};
+
+	const groups = await fetchParticipatingGroupsLight(client);
+
+	assert.deepEqual(capturedQuery, {
+		tag: "iq",
+		attrs: {
+			to: "@g.us",
+			xmlns: "w:g2",
+			type: "get",
+		},
+		content: [{ tag: "participating", attrs: {} }],
+	});
+	assert.equal(groups["123456789-987654321@g.us"].subject, "Alpha Group");
+	assert.equal(groups["123456789-987654321@g.us"].size, 42);
+});
+
+test("resyncWhatsAppContactsAndGroups refreshes app state and persists light group results", async () => {
+	const originalContacts = { ...state.contacts };
+	const originalLogger = state.logger;
+	const originalStartTime = state.startTime;
+	let appStatePayload = null;
+	let resyncedCollections = null;
+
+		try {
+			groupMetadataCache.clear();
+			restoreObject(state.contacts, {});
+			state.logger = { warn() {}, error() {}, info() {}, debug() {} };
+		state.startTime = 123;
+		const client = {
+			contacts: state.contacts,
+			authState: {
+				keys: {
+					async set(payload) {
+						appStatePayload = payload;
+					},
+				},
+			},
+			async resyncAppState(collections) {
+				resyncedCollections = collections;
+				state.contacts["15551234567@s.whatsapp.net"] = "Alice";
+			},
+			async query() {
+				return {
+					tag: "iq",
+					attrs: {},
+					content: [
+						{
+							tag: "groups",
+							attrs: {},
+							content: [
+								{
+									tag: "group",
+									attrs: {
+										id: "111222333-444555666",
+										subject: "Project Group",
+									},
+								},
+							],
+						},
+					],
+				};
+			},
+			async groupFetchAllParticipating() {
+				throw new Error("heavy group fetch should not be called");
+			},
+		};
+
+		const result = await resyncWhatsAppContactsAndGroups(client);
+		const persistedContacts = await storage.parseContacts();
+
+		assert.deepEqual(appStatePayload, {
+			"app-state-sync-version": { critical_unblock_low: null },
+		});
+		assert.deepEqual(resyncedCollections, ["critical_unblock_low"]);
+		assert.equal(result.groupCount, 1);
+		assert.equal(result.contactCount, 2);
+		assert.equal(state.contacts["15551234567@s.whatsapp.net"], "Alice");
+		assert.equal(state.contacts["111222333-444555666@g.us"], "Project Group");
+		assert.equal(client.contacts["111222333-444555666@g.us"], "Project Group");
+		assert.equal(groupMetadataCache.get("111222333-444555666@g.us"), undefined);
+		assert.equal(
+			persistedContacts["111222333-444555666@g.us"],
+			"Project Group",
+		);
+	} finally {
+		restoreObject(state.contacts, originalContacts);
+		state.logger = originalLogger;
+		state.startTime = originalStartTime;
+	}
+});


### PR DESCRIPTION
This fixes RC10 regressions where WhatsApp pairing/reconnect and `/resync` could crash the bot with heap exhaustion.

Changes:
- Bound Baileys logging so bundled stack traces and binary payloads do not explode `logs.txt` / `terminal.log`.
- Skip expensive WhatsApp history-sync payload processing while preserving normal live/offline message delivery.
- Avoid eager `groupFetchAllParticipating()` on reconnect.
- Rework `/resync` to refresh contacts/app-state and use a lightweight participating-groups query for `/list` data.
- Keep full group metadata fetches on-demand for send-time behavior, so group sending still gets participants/addressing metadata when needed.
- Ignore local `testing env/`.
- Add regression tests and update docs.