### PR TITLE
Add configurable forum host names for thread mode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,8 +22,8 @@ Create a brand-new WhatsApp conversation and link it using the current default c
 Usage: `/start contact:<phone number or saved contact name>`
 
 ### `/defaultchat`
-Choose whether new WhatsApp chats are created as regular Discord channels or as forum threads under managed `whatsapp-threads` channels.  
-Usage: `/defaultchat mode:<channel|thread>`
+Choose whether new WhatsApp chats are created as regular Discord channels or as forum threads under managed forum channels.  
+Usage: `/defaultchat mode:<channel|thread> host_name:<optional forum name>`
 
 ### `/threadnotifications`
 Toggle the one-time notification post WA2DC sends when it creates a new WhatsApp thread.  
@@ -60,7 +60,8 @@ Usage: `/setpinduration duration:<24h|7d|30d>`
 Thread mode notes:
 
 - `channel` remains the default for backward compatibility.
-- In `thread` mode, WA2DC creates forum threads under auto-managed forum channels named `whatsapp-threads`, `whatsapp-threads-2`, and so on.
+- In `thread` mode, WA2DC creates forum threads under auto-managed forum channels named `whatsapp-threads`, `whatsapp-threads-2`, and so on, unless you provide `host_name`.
+- `host_name` is sanitized into a Discord channel name and only affects newly created managed forum channels.
 - Existing channel links continue working unchanged after you switch the default.
 - Thread notification pings are sent only once when the thread is first created, never on every mirrored message.
 

--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -69,3 +69,4 @@ Routing may be restricted by deployment settings. Message-flow changes must pres
   Mirror incoming WhatsApp newsletter reactions via `newsletter.reaction` and/or raw `live_updates` notifications, keyed by `server_id`.
 
 When Discord links target forum threads instead of plain channels, resolve routing through the thread target ID while preserving the parent webhook host channel ID for webhook operations and recovery.
+Managed forum host discovery is scoped by the configured host name and the Discord bot owner marker in the forum topic so separate WA2DC bot users do not silently share the same default thread host.

--- a/docs/dev/storage-and-side-effects.md
+++ b/docs/dev/storage-and-side-effects.md
@@ -16,7 +16,7 @@ Optional encryption-at-rest is enabled by `WA2DC_DB_PASSPHRASE`; passphrase hand
 
 Chat-link records in persisted `chats` state now store the webhook host `channelId` plus an optional `threadId` for thread-mode links.
 Legacy channel-only records must continue to load without migration steps.
-Thread-mode settings such as `DefaultChatType`, `ThreadNotificationsEnabled`, `ThreadNotificationRoles`, and `ThreadNotificationUsers` are regular persisted settings and must keep backward-compatible defaults.
+Thread-mode settings such as `DefaultChatType`, `DefaultThreadHostName`, `ThreadNotificationsEnabled`, `ThreadNotificationRoles`, and `ThreadNotificationUsers` are regular persisted settings and must keep backward-compatible defaults.
 
 ## Runtime artifacts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wa2dc",
-	"version": "2.4.0-alpha.0",
+	"version": "2.4.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wa2dc",
-			"version": "2.4.0-alpha.0",
+			"version": "2.4.0-alpha.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wa2dc",
-	"version": "2.4.0-alpha.0",
+	"version": "2.4.0-alpha.1",
 	"description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
 	"type": "module",
 	"main": "src/runner.js",

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -29,10 +29,10 @@ import state from "./state.js";
 import storage from "./storage.js";
 import utils from "./utils.js";
 import {
-	PAIRING_CODE_BROWSER_PROFILE,
-	WHATSAPP_BROWSER_PROFILE_ENV,
 	isWhatsAppBrowserProfile,
+	PAIRING_CODE_BROWSER_PROFILE,
 	saveWhatsAppPairingCodeBrowserProfile,
+	WHATSAPP_BROWSER_PROFILE_ENV,
 } from "./whatsappHandler.js";
 import { resyncWhatsAppContactsAndGroups } from "./whatsappResync.js";
 
@@ -54,6 +54,15 @@ const PIN_DURATION_PRESETS = {
 	"7d": 7 * 24 * 60 * 60,
 	"30d": 30 * 24 * 60 * 60,
 };
+const normalizeManagedThreadHostNameOption = (value) =>
+	String(value || "")
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/gu, "-")
+		.replace(/[^a-z0-9_-]+/gu, "")
+		.replace(/-+/gu, "-")
+		.replace(/^[-_]+|[-_]+$/gu, "")
+		.slice(0, 80);
 const AnnouncementChannelTypes = [ChannelType.GuildAnnouncement, "GUILD_NEWS"];
 const TextBridgeChannelTypes = [
 	ChannelType.GuildText,
@@ -3920,6 +3929,13 @@ const commandHandlers = {
 					{ name: "Thread", value: "thread" },
 				],
 			},
+			{
+				name: "host_name",
+				description:
+					"Optional forum-channel name for new thread-mode WhatsApp chats.",
+				type: ApplicationCommandOptionTypes.STRING,
+				required: false,
+			},
 		],
 		async execute(ctx) {
 			const mode = ctx.getStringOption("mode");
@@ -3927,11 +3943,17 @@ const commandHandlers = {
 				await ctx.reply("Choose either `channel` or `thread`.");
 				return;
 			}
+			const hostName = normalizeManagedThreadHostNameOption(
+				ctx.getStringOption("host_name"),
+			);
 			state.settings.DefaultChatType = mode;
+			if (mode === "thread") {
+				state.settings.DefaultThreadHostName = hostName;
+			}
 			await storage.saveSettings().catch(() => {});
 			await ctx.reply(
 				mode === "thread"
-					? "Default chat mode set to `thread`. New WhatsApp chats will be created as forum threads under managed `whatsapp-threads` channels."
+					? `Default chat mode set to \`thread\`. New WhatsApp chats will be created as forum threads under managed \`${hostName || "whatsapp-threads"}\` channels.`
 					: "Default chat mode set to `channel`. New WhatsApp chats will keep using regular Discord channels.",
 			);
 		},

--- a/src/state.js
+++ b/src/state.js
@@ -50,6 +50,7 @@ const state = {
 		RollbackPromptMessage: null,
 		PinDurationSeconds: 7 * 24 * 60 * 60,
 		DefaultChatType: "channel",
+		DefaultThreadHostName: "",
 		ThreadNotificationsEnabled: false,
 		ThreadNotificationRoles: [],
 		ThreadNotificationUsers: [],

--- a/src/storage.js
+++ b/src/storage.js
@@ -323,6 +323,10 @@ const storage = {
 			if (parsed.DefaultChatType !== "thread") {
 				parsed.DefaultChatType = "channel";
 			}
+			parsed.DefaultThreadHostName =
+				typeof parsed.DefaultThreadHostName === "string"
+					? parsed.DefaultThreadHostName.trim()
+					: "";
 			if (Object.hasOwn(parsed, "ThreadNotificationsEnabled")) {
 				parsed.ThreadNotificationsEnabled = Boolean(
 					parsed.ThreadNotificationsEnabled,

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,7 +129,9 @@ const LINK_PREVIEW_MAX_BYTES = 1024 * 1024;
 const LINK_PREVIEW_THUMB_MAX_BYTES = 8 * 1024 * 1024;
 const FORUM_CHANNEL_TYPES = [ChannelType.GuildForum, "GUILD_FORUM"];
 const MANAGED_THREAD_HOST_BASE_NAME = "whatsapp-threads";
+const MANAGED_THREAD_HOST_OWNER_PREFIX = "WA2DC managed thread host for bot ";
 const MANAGED_THREAD_HOST_SOFT_LIMIT = 500;
+const MANAGED_THREAD_HOST_NAME_MAX_LENGTH = 80;
 const DISCORD_MAX_FILES_PER_MESSAGE = 10;
 const EXPLICIT_URL_REGEX = /<?https?:\/\/[^\s>]+>?/i;
 const BARE_URL_REGEX =
@@ -743,7 +745,11 @@ const isWhatsAppViewOnceMessageType = (msgType = "") =>
 		"viewOnceMessageV2",
 		"viewOnceMessageV2Extension",
 	].includes(msgType);
-const isWhatsAppViewOnceMediaMessage = (rawMsg = {}, msgType = "", msg = {}) => {
+const isWhatsAppViewOnceMediaMessage = (
+	rawMsg = {},
+	msgType = "",
+	msg = {},
+) => {
 	if (isWhatsAppViewOnceMessageType(msgType)) return true;
 	if (msg?.viewOnce === true) return true;
 	const typedMessage = rawMsg?.message?.[msgType];
@@ -2589,21 +2595,72 @@ const uniqueDiscordIds = (value = []) => [
 		(Array.isArray(value) ? value : []).map(normalizeDiscordId).filter(Boolean),
 	),
 ];
-const getManagedThreadHostName = (index = 0) =>
-	index <= 0
-		? MANAGED_THREAD_HOST_BASE_NAME
-		: `${MANAGED_THREAD_HOST_BASE_NAME}-${index + 1}`;
+const normalizeManagedThreadHostBaseName = (value) => {
+	const normalized = String(value || "")
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/gu, "-")
+		.replace(/[^a-z0-9_-]+/gu, "")
+		.replace(/-+/gu, "-")
+		.replace(/^[-_]+|[-_]+$/gu, "")
+		.slice(0, MANAGED_THREAD_HOST_NAME_MAX_LENGTH);
+	return normalized || MANAGED_THREAD_HOST_BASE_NAME;
+};
+const getManagedThreadHostBaseName = () =>
+	normalizeManagedThreadHostBaseName(state.settings?.DefaultThreadHostName);
+const getManagedThreadHostName = (
+	index = 0,
+	baseName = getManagedThreadHostBaseName(),
+) => (index <= 0 ? baseName : `${baseName}-${index + 1}`);
+const managedThreadHostNamePattern = (baseName) =>
+	new RegExp(`^${escapeRegex(baseName)}-(\\d+)$`, "iu");
+const getManagedThreadHostNameBase = (name = "") => {
+	const normalizedName = String(name || "").toLowerCase();
+	const configuredBase = getManagedThreadHostBaseName();
+	if (normalizedName === configuredBase) return configuredBase;
+	if (normalizedName === MANAGED_THREAD_HOST_BASE_NAME) {
+		return MANAGED_THREAD_HOST_BASE_NAME;
+	}
+	if (managedThreadHostNamePattern(configuredBase).test(normalizedName)) {
+		return configuredBase;
+	}
+	if (
+		managedThreadHostNamePattern(MANAGED_THREAD_HOST_BASE_NAME).test(
+			normalizedName,
+		)
+	) {
+		return MANAGED_THREAD_HOST_BASE_NAME;
+	}
+	return null;
+};
 const isManagedThreadHostName = (name = "") =>
-	typeof name === "string" &&
-	(name === MANAGED_THREAD_HOST_BASE_NAME ||
-		/^whatsapp-threads-\d+$/i.test(name));
+	typeof name === "string" && Boolean(getManagedThreadHostNameBase(name));
 const getManagedThreadHostIndex = (channel = {}) => {
 	const name = String(channel?.name || "").toLowerCase();
-	if (name === MANAGED_THREAD_HOST_BASE_NAME) return 0;
-	const match = name.match(/^whatsapp-threads-(\d+)$/i);
+	const baseName = getManagedThreadHostNameBase(name);
+	if (!baseName) return null;
+	if (name === baseName) return 0;
+	const match = name.match(managedThreadHostNamePattern(baseName));
 	if (!match) return null;
 	const parsed = Number.parseInt(match[1], 10);
 	return Number.isFinite(parsed) && parsed >= 2 ? parsed - 1 : null;
+};
+const getManagedThreadHostTopic = (botId = state.dcClient?.user?.id) =>
+	botId ? `${MANAGED_THREAD_HOST_OWNER_PREFIX}${botId}` : "";
+const getManagedThreadHostOwnerId = (channel = {}) => {
+	const topic = typeof channel?.topic === "string" ? channel.topic : "";
+	const markerIndex = topic.indexOf(MANAGED_THREAD_HOST_OWNER_PREFIX);
+	if (markerIndex < 0) return null;
+	const ownerId = topic
+		.slice(markerIndex + MANAGED_THREAD_HOST_OWNER_PREFIX.length)
+		.trim()
+		.split(/\s+/u)[0];
+	return normalizeDiscordId(ownerId);
+};
+const isManagedThreadHostOwnedByCurrentBot = (channel = {}) => {
+	const ownerId = getManagedThreadHostOwnerId(channel);
+	const currentBotId = normalizeDiscordId(state.dcClient?.user?.id);
+	return !ownerId || !currentBotId || ownerId === currentBotId;
 };
 const buildStoredChatLink = (webhook, existingChat = {}, overrides = {}) => {
 	const threadId = normalizeDiscordId(
@@ -2674,6 +2731,34 @@ const discord = {
 			isForumChannelType(channel?.type) &&
 			isManagedThreadHostName(channel?.name)
 		);
+	},
+	isOwnedManagedThreadHostChannel(channel = {}) {
+		return (
+			this.isManagedThreadHostChannel(channel) &&
+			isManagedThreadHostOwnedByCurrentBot(channel)
+		);
+	},
+	async ensureManagedThreadHostOwnership(channel) {
+		if (!this.isOwnedManagedThreadHostChannel(channel)) return channel;
+		const ownerTopic = getManagedThreadHostTopic();
+		if (!ownerTopic || getManagedThreadHostOwnerId(channel)) return channel;
+
+		if (typeof channel.setTopic === "function") {
+			try {
+				await channel.setTopic(ownerTopic);
+				channel.topic = ownerTopic;
+			} catch (err) {
+				state.logger?.warn(
+					{
+						err,
+						channelId: channel.id,
+						botId: state.dcClient?.user?.id,
+					},
+					"Could not mark managed thread host ownership",
+				);
+			}
+		}
+		return channel;
 	},
 	partitionText(text) {
 		return text.match(/(.|[\r\n]){1,2000}/g) || [];
@@ -3023,8 +3108,8 @@ const discord = {
 		const preferredHost = preferredHostChannelId
 			? guild.channels.cache.get(preferredHostChannelId) || null
 			: null;
-		if (preferredHost && this.isManagedThreadHostChannel(preferredHost)) {
-			return preferredHost;
+		if (preferredHost && this.isOwnedManagedThreadHostChannel(preferredHost)) {
+			return this.ensureManagedThreadHostOwnership(preferredHost);
 		}
 
 		const threadCounts = new Map();
@@ -3038,23 +3123,26 @@ const discord = {
 			);
 		});
 
-		const managedHosts = [...guild.channels.cache.values()]
+		const allManagedHosts = [...guild.channels.cache.values()]
 			.filter((channel) => this.isManagedThreadHostChannel(channel))
 			.sort(
 				(a, b) =>
 					(getManagedThreadHostIndex(a) ?? Number.MAX_SAFE_INTEGER) -
 					(getManagedThreadHostIndex(b) ?? Number.MAX_SAFE_INTEGER),
 			);
+		const managedHosts = allManagedHosts.filter((channel) =>
+			isManagedThreadHostOwnedByCurrentBot(channel),
+		);
 		const availableHost = managedHosts.find(
 			(channel) =>
 				(threadCounts.get(channel.id) || 0) < MANAGED_THREAD_HOST_SOFT_LIMIT,
 		);
 		if (availableHost) {
-			return availableHost;
+			return this.ensureManagedThreadHostOwnership(availableHost);
 		}
 
 		const nextIndex =
-			managedHosts.reduce(
+			allManagedHosts.reduce(
 				(maxIndex, channel) =>
 					Math.max(maxIndex, getManagedThreadHostIndex(channel) ?? -1),
 				-1,
@@ -3062,6 +3150,7 @@ const discord = {
 		return guild.channels.create({
 			name: getManagedThreadHostName(nextIndex),
 			type: ChannelType.GuildForum,
+			topic: getManagedThreadHostTopic() || undefined,
 			parent: await this.getCategory(0),
 		});
 	},

--- a/src/whatsappHandler.js
+++ b/src/whatsappHandler.js
@@ -197,6 +197,10 @@ const WHATSAPP_PAIRING_CODE_BROWSER_PROFILE_STORAGE_KEY =
 export const WHATSAPP_BROWSER_PROFILE_ENV = "WA2DC_WHATSAPP_BROWSER";
 export const DEFAULT_WHATSAPP_BROWSER_PROFILE = "android";
 export const PAIRING_CODE_BROWSER_PROFILE = "macos-chrome";
+const getBaileysBrowserProfile = (preset, args, fallback) => {
+	const factory = Browsers?.[preset];
+	return typeof factory === "function" ? factory(...args) : fallback;
+};
 export const resolveWhatsAppBrowserProfile = (
 	value = DEFAULT_WHATSAPP_BROWSER_PROFILE,
 ) => {
@@ -206,18 +210,34 @@ export const resolveWhatsAppBrowserProfile = (
 			.toLowerCase()
 	) {
 		case "android":
-			return Browsers.android("13");
+			return getBaileysBrowserProfile("android", ["13"], ["13", "Android", ""]);
 		case "macos-chrome":
 		case "macos":
-			return Browsers.macOS("Chrome");
+			return getBaileysBrowserProfile(
+				"macOS",
+				["Chrome"],
+				["Mac OS", "Chrome", "14.4.1"],
+			);
 		case "windows-chrome":
 		case "windows":
-			return Browsers.windows("Chrome");
+			return getBaileysBrowserProfile(
+				"windows",
+				["Chrome"],
+				["Windows", "Chrome", "10.0.22631"],
+			);
 		case "ubuntu-chrome":
 		case "ubuntu":
-			return Browsers.ubuntu("Chrome");
+			return getBaileysBrowserProfile(
+				"ubuntu",
+				["Chrome"],
+				["Ubuntu", "Chrome", "22.04.4"],
+			);
 		case "baileys":
-			return Browsers.baileys("Chrome");
+			return getBaileysBrowserProfile(
+				"baileys",
+				["Chrome"],
+				["Baileys", "Chrome", "6.5.0"],
+			);
 		default:
 			return resolveWhatsAppBrowserProfile(DEFAULT_WHATSAPP_BROWSER_PROFILE);
 	}

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -9,6 +9,7 @@ test("Default settings include DownloadDir", () => {
 	assert.equal(settings.redirectAnnouncementWebhooks, false);
 	assert.equal(settings.WhatsAppDiscordMediaBurstSize, 10);
 	assert.equal(settings.DefaultChatType, "channel");
+	assert.equal(settings.DefaultThreadHostName, "");
 	assert.equal(settings.ThreadNotificationsEnabled, false);
 	assert.deepEqual(settings.ThreadNotificationRoles, []);
 	assert.deepEqual(settings.ThreadNotificationUsers, []);

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -72,6 +72,7 @@ test("parseSettings merges defaults when older settings are missing keys", async
 		assert.equal(settings.PinDurationSeconds, 7 * 24 * 60 * 60);
 		assert.equal(settings.WhatsAppDiscordMediaBurstSize, 10);
 		assert.equal(settings.DefaultChatType, "channel");
+		assert.equal(settings.DefaultThreadHostName, "");
 		assert.equal(settings.ThreadNotificationsEnabled, false);
 		assert.deepEqual(settings.ThreadNotificationRoles, []);
 		assert.deepEqual(settings.ThreadNotificationUsers, []);

--- a/tests/threadMode.test.js
+++ b/tests/threadMode.test.js
@@ -131,12 +131,17 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 	};
 	const originalSettings = {
 		DefaultChatType: state.settings.DefaultChatType,
+		DefaultThreadHostName: state.settings.DefaultThreadHostName,
 		Categories: Array.isArray(state.settings.Categories)
 			? [...state.settings.Categories]
 			: [],
 		ThreadNotificationsEnabled: state.settings.ThreadNotificationsEnabled,
-		ThreadNotificationRoles: [...(state.settings.ThreadNotificationRoles || [])],
-		ThreadNotificationUsers: [...(state.settings.ThreadNotificationUsers || [])],
+		ThreadNotificationRoles: [
+			...(state.settings.ThreadNotificationRoles || []),
+		],
+		ThreadNotificationUsers: [
+			...(state.settings.ThreadNotificationUsers || []),
+		],
 	};
 	const originalContacts = { ...state.contacts };
 	const originalChats = { ...state.chats };
@@ -145,6 +150,7 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 
 	try {
 		state.settings.DefaultChatType = "thread";
+		state.settings.DefaultThreadHostName = "";
 		state.settings.Categories = ["cat-1"];
 		state.settings.ThreadNotificationsEnabled = true;
 		state.settings.ThreadNotificationRoles = ["111"];
@@ -204,6 +210,7 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 				async create(payload) {
 					createdChannels.push(payload);
 					if (payload.type === ChannelType.GuildForum) {
+						forumHost.topic = payload.topic;
 						channels.set(forumHost.id, forumHost);
 						return forumHost;
 					}
@@ -218,13 +225,21 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 			},
 		});
 
-		const webhook = await utils.discord.getOrCreateChannel("123@s.whatsapp.net");
+		const webhook =
+			await utils.discord.getOrCreateChannel("123@s.whatsapp.net");
 
 		assert.equal(createdChannels.length, 1);
 		assert.equal(createdChannels[0]?.type, ChannelType.GuildForum);
+		assert.equal(
+			createdChannels[0]?.topic,
+			"WA2DC managed thread host for bot bot-1",
+		);
 		assert.equal(createdThreads.length, 1);
 		assert.equal(createdThreads[0]?.name, "Alice");
-		assert.match(createdThreads[0]?.message?.content || "", /New WhatsApp chat/);
+		assert.match(
+			createdThreads[0]?.message?.content || "",
+			/New WhatsApp chat/,
+		);
 		assert.match(createdThreads[0]?.message?.content || "", /<@&111>/);
 		assert.match(createdThreads[0]?.message?.content || "", /<@222>/);
 		assert.equal(state.chats["123@s.whatsapp.net"]?.channelId, "forum-1");
@@ -233,6 +248,8 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 	} finally {
 		utils.discord.getGuild = originalDiscordUtils.getGuild;
 		state.settings.DefaultChatType = originalSettings.DefaultChatType;
+		state.settings.DefaultThreadHostName =
+			originalSettings.DefaultThreadHostName;
 		state.settings.Categories = originalSettings.Categories;
 		state.settings.ThreadNotificationsEnabled =
 			originalSettings.ThreadNotificationsEnabled;
@@ -240,6 +257,129 @@ test("utils.discord.getOrCreateChannel creates a managed forum thread when threa
 			originalSettings.ThreadNotificationRoles;
 		state.settings.ThreadNotificationUsers =
 			originalSettings.ThreadNotificationUsers;
+		restoreObject(state.contacts, originalContacts);
+		restoreObject(state.chats, originalChats);
+		restoreObject(state.goccRuns, originalGoccRuns);
+		state.dcClient = originalDcClient;
+	}
+});
+
+test("thread mode creates a separate managed forum when another bot owns the existing host", async () => {
+	const originalDiscordUtils = {
+		getGuild: utils.discord.getGuild,
+	};
+	const originalSettings = {
+		DefaultChatType: state.settings.DefaultChatType,
+		DefaultThreadHostName: state.settings.DefaultThreadHostName,
+		Categories: Array.isArray(state.settings.Categories)
+			? [...state.settings.Categories]
+			: [],
+	};
+	const originalContacts = { ...state.contacts };
+	const originalChats = { ...state.chats };
+	const originalGoccRuns = { ...state.goccRuns };
+	const originalDcClient = state.dcClient;
+
+	try {
+		state.settings.DefaultChatType = "thread";
+		state.settings.DefaultThreadHostName = "Team A Threads";
+		state.settings.Categories = ["cat-1"];
+		state.contacts["123@s.whatsapp.net"] = "Alice";
+		restoreObject(state.chats, {});
+		restoreObject(state.goccRuns, {});
+		state.dcClient = { user: { id: "bot-2" } };
+
+		const channels = new Collection();
+		channels.set("cat-1", {
+			id: "cat-1",
+			type: ChannelType.GuildCategory,
+		});
+		channels.set("forum-other", {
+			id: "forum-other",
+			name: "team-a-threads",
+			type: ChannelType.GuildForum,
+			parentId: "cat-1",
+			topic: "WA2DC managed thread host for bot bot-1",
+		});
+
+		const createdChannels = [];
+		const createdThreads = [];
+		const ownedForum = {
+			id: "forum-owned",
+			name: "team-a-threads-2",
+			type: ChannelType.GuildForum,
+			parentId: "cat-1",
+			topic: null,
+			async fetchWebhooks() {
+				return { find: () => null };
+			},
+			async createWebhook() {
+				return {
+					id: "wh-owned",
+					type: 1,
+					token: "tok",
+					channelId: "forum-owned",
+					client: { options: {} },
+				};
+			},
+			threads: {
+				create: async (payload) => {
+					createdThreads.push(payload);
+					const thread = {
+						id: "thread-owned",
+						type: ChannelType.PublicThread,
+						parentId: "forum-owned",
+						name: payload.name,
+					};
+					channels.set(thread.id, thread);
+					return thread;
+				},
+			},
+		};
+
+		utils.discord.getGuild = async () => ({
+			channels: {
+				cache: channels,
+				async fetch(id) {
+					if (typeof id === "undefined") return channels;
+					return channels.get(id) || null;
+				},
+				async create(payload) {
+					createdChannels.push(payload);
+					if (payload.type === ChannelType.GuildForum) {
+						ownedForum.name = payload.name;
+						ownedForum.topic = payload.topic;
+						channels.set(ownedForum.id, ownedForum);
+						return ownedForum;
+					}
+					const category = {
+						id: "cat-created",
+						name: payload.name,
+						type: payload.type,
+					};
+					channels.set(category.id, category);
+					return category;
+				},
+			},
+		});
+
+		await utils.discord.getOrCreateChannel("123@s.whatsapp.net");
+
+		assert.equal(createdChannels.length, 1);
+		assert.equal(createdChannels[0]?.name, "team-a-threads-2");
+		assert.equal(
+			createdChannels[0]?.topic,
+			"WA2DC managed thread host for bot bot-2",
+		);
+		assert.equal(createdThreads.length, 1);
+		assert.equal(state.chats["123@s.whatsapp.net"]?.channelId, "forum-owned");
+		assert.equal(state.chats["123@s.whatsapp.net"]?.threadId, "thread-owned");
+	} finally {
+		utils.discord.getGuild = originalDiscordUtils.getGuild;
+		state.settings.DefaultChatType = originalSettings.DefaultChatType;
+		state.settings.DefaultThreadHostName =
+			originalSettings.DefaultThreadHostName;
+		state.settings.Categories = originalSettings.Categories;
 		restoreObject(state.contacts, originalContacts);
 		restoreObject(state.chats, originalChats);
 		restoreObject(state.goccRuns, originalGoccRuns);
@@ -257,6 +397,7 @@ test("/defaultchat and /threadnotifications update persisted thread settings", a
 		GuildID: state.settings.GuildID,
 		ControlChannelID: state.settings.ControlChannelID,
 		DefaultChatType: state.settings.DefaultChatType,
+		DefaultThreadHostName: state.settings.DefaultThreadHostName,
 		ThreadNotificationsEnabled: state.settings.ThreadNotificationsEnabled,
 	};
 	const originalDcClient = state.dcClient;
@@ -266,6 +407,7 @@ test("/defaultchat and /threadnotifications update persisted thread settings", a
 		state.settings.GuildID = "guild";
 		state.settings.ControlChannelID = "control";
 		state.settings.DefaultChatType = "channel";
+		state.settings.DefaultThreadHostName = "";
 		state.settings.ThreadNotificationsEnabled = false;
 
 		utils.discord.getGuild = async () => ({
@@ -275,22 +417,25 @@ test("/defaultchat and /threadnotifications update persisted thread settings", a
 
 		const fakeClient = new FakeDiscordClient();
 		setClientFactoryOverrides({ createDiscordClient: () => fakeClient });
-		const discordHandler = await importDiscordHandler("thread-settings-commands");
+		const discordHandler = await importDiscordHandler(
+			"thread-settings-commands",
+		);
 		state.dcClient = await discordHandler.start();
 		await delay(0);
 
 		const defaultChatInteraction = createInteraction({
 			channelId: "control",
 			commandName: "defaultchat",
-			stringOptions: { mode: "thread" },
+			stringOptions: { mode: "thread", host_name: " Team A Threads! " },
 		});
 		fakeClient.emit("interactionCreate", defaultChatInteraction);
 		await delay(0);
 
 		assert.equal(state.settings.DefaultChatType, "thread");
+		assert.equal(state.settings.DefaultThreadHostName, "team-a-threads");
 		assert.match(
 			String(defaultChatInteraction.records.editReply[0]?.content || ""),
-			/Default chat mode set to `thread`/i,
+			/`team-a-threads` channels/i,
 		);
 
 		const notificationsInteraction = createInteraction({
@@ -313,6 +458,8 @@ test("/defaultchat and /threadnotifications update persisted thread settings", a
 		state.settings.GuildID = originalSettings.GuildID;
 		state.settings.ControlChannelID = originalSettings.ControlChannelID;
 		state.settings.DefaultChatType = originalSettings.DefaultChatType;
+		state.settings.DefaultThreadHostName =
+			originalSettings.DefaultThreadHostName;
 		state.settings.ThreadNotificationsEnabled =
 			originalSettings.ThreadNotificationsEnabled;
 		state.dcClient = originalDcClient;
@@ -330,8 +477,12 @@ test("/threadtargets uses one command for add/remove/list across roles and users
 		GuildID: state.settings.GuildID,
 		ControlChannelID: state.settings.ControlChannelID,
 		ThreadNotificationsEnabled: state.settings.ThreadNotificationsEnabled,
-		ThreadNotificationRoles: [...(state.settings.ThreadNotificationRoles || [])],
-		ThreadNotificationUsers: [...(state.settings.ThreadNotificationUsers || [])],
+		ThreadNotificationRoles: [
+			...(state.settings.ThreadNotificationRoles || []),
+		],
+		ThreadNotificationUsers: [
+			...(state.settings.ThreadNotificationUsers || []),
+		],
 	};
 	const originalDcClient = state.dcClient;
 

--- a/tests/whatsappBrowserProfile.test.js
+++ b/tests/whatsappBrowserProfile.test.js
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { Browsers } from "@whiskeysockets/baileys";
+
 import {
 	resolveWhatsAppBrowserProfile,
 	selectWhatsAppBrowserProfile,
@@ -70,6 +72,20 @@ test("WhatsApp browser profile override supports pairing-code experiments", () =
 		"Android",
 		"",
 	]);
+});
+
+test("WhatsApp Android browser profile has a local fallback when Baileys is unpatched", () => {
+	const originalAndroid = Browsers.android;
+	try {
+		Browsers.android = undefined;
+		assert.deepEqual(resolveWhatsAppBrowserProfile("android"), [
+			"13",
+			"Android",
+			"",
+		]);
+	} finally {
+		Browsers.android = originalAndroid;
+	}
 });
 
 test("WhatsApp browser profile selection uses Android for fresh QR pairing", () => {


### PR DESCRIPTION
- add optional `/defaultchat host_name` for thread-mode forum hosts
- scope managed forum host discovery by host name and bot owner marker
- persist `DefaultThreadHostName` with backward-compatible defaults
- fixes Android browser startup when the Baileys patch is missing by falling back to the Android browser tuple
- update docs and thread-mode tests