### PR TITLE
feat: Add opt-in WhatsApp audio MP3 conversion

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -242,6 +242,7 @@ How to find PN/LID:
 Defaults (out of the box):
 
 - WhatsApp → Discord media bursts use batches of `10` attachments (`/setwamediaburstsize` can lower this for slower machines or unstable connections).
+- WhatsApp audio is mirrored in its original format by default (`/waaudiomp3 enabled:true` opts in to MP3 conversion for older clients).
 - Local downloads are disabled (`/localdownloads enabled:true` to turn on).
 - Download directory is `./downloads` and pruning is disabled (`/setdownloadlimit`, `/setdownloadmaxage`, `/setdownloadminfree` all default to `0` = off).
 - Local download server is disabled; when enabled it defaults to local-only (`127.0.0.1` bind, `localhost` URLs, port `8080`).
@@ -253,6 +254,12 @@ Usage: `/setwamediaburstsize count:<1-10>`
 Default: `10`  
 Lower values can help on slower machines or unstable connections, at the cost of producing more Discord messages for large WhatsApp image bursts.
 - Download links are signed (survive restarts) and never expire by default (`/setdownloadlinkttl seconds:0`).
+
+### `/waaudiomp3`
+Toggle MP3 conversion for WhatsApp audio before uploading it to Discord.  
+Usage: `/waaudiomp3 enabled:<true|false>`  
+Default: `false` (original WhatsApp audio is preserved).  
+Requires `ffmpeg`; if conversion is unavailable or fails, WA2DC falls back to the original WhatsApp audio.
 
 To make download links reachable from other devices (phone/PC), you usually want:
 

--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -43,6 +43,7 @@ Respect transport constraints when emitting output:
 - do not flatten or duplicate animated Discord media just to satisfy static image normalization paths; when Discord exposes both a GIF file entry and its preview video for the same upload, prefer a single animated send candidate
 - when Discord GIF providers (for example Tenor/Giphy) expose extensionless video URLs plus static preview thumbnails, infer the animated video send from the provider embed and suppress the duplicate preview image
 - when WhatsApp exposes GIFs as `videoMessage` payloads with `gifPlayback`, prefer transcoding them into real Discord GIF attachments when runtime tooling (`ffmpeg`) is available; if transcoding is unavailable or fails, fall back to the original video attachment instead of dropping media
+- keep WhatsApp audio mirroring in the original format by default; only convert WhatsApp audio to MP3 when `WhatsAppAudioConversionFormat` is `mp3`, and fall back to the original attachment if `ffmpeg` is unavailable or conversion fails
 - prefer the sticker asset URL exposed by Discord over reconstructing sticker CDN/proxy URLs locally; convert Discord sticker assets into WhatsApp sticker payloads when possible, including animated Lottie stickers via the dedicated renderer path
 - keep Discord -> WhatsApp bare-URL normalization narrow enough that plain email addresses are forwarded unchanged instead of being rewritten into malformed `https://.../@domain` text
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,6 +31,12 @@ WA2DC can mirror Discord voice-style attachments to WhatsApp voice notes (`ptt`)
 - For best compatibility, install `ffmpeg` on the host running WA2DC. The bridge will transcode Discord voice uploads to Opus/Ogg mono before sending.
 - If `ffmpeg` is not installed, WA2DC still attempts a raw audio send, but some voice uploads may fail on WhatsApp clients.
 
+## Playing WhatsApp audio on older Discord clients or phones
+WhatsApp audio is mirrored to Discord in its original format by default, which is best for modern clients.
+
+- Some older devices support Ogg Vorbis but not WhatsApp's usual Ogg/Opus audio. Use `/waaudiomp3 enabled:true` to convert WhatsApp audio to MP3 before Discord upload.
+- MP3 conversion requires `ffmpeg`. If `ffmpeg` is missing or conversion fails, WA2DC falls back to the original WhatsApp audio attachment.
+
 ## Why did a WhatsApp GIF arrive on Discord as a video?
 WhatsApp usually exposes GIF sends as short `videoMessage` payloads flagged with `gifPlayback`, not as literal `.gif` files.
 

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -4877,6 +4877,29 @@ const commandHandlers = {
 			);
 		},
 	},
+	waaudiomp3: {
+		description: "Toggle MP3 conversion for WhatsApp audio sent to Discord.",
+		options: [
+			{
+				name: "enabled",
+				description:
+					"Whether WhatsApp audio should be converted to MP3 before Discord upload.",
+				type: ApplicationCommandOptionTypes.BOOLEAN,
+				required: true,
+			},
+		],
+		async execute(ctx) {
+			const enabled = Boolean(ctx.getBooleanOption("enabled"));
+			state.settings.WhatsAppAudioConversionFormat = enabled
+				? "mp3"
+				: "original";
+			await ctx.reply(
+				enabled
+					? "WhatsApp audio MP3 conversion is enabled. Install ffmpeg on the host for conversion."
+					: "WhatsApp audio MP3 conversion is disabled. WhatsApp audio will be mirrored in its original format.",
+			);
+		},
+	},
 	hidephonenumbers: {
 		description:
 			"Hide WhatsApp phone numbers on Discord (use pseudonyms when needed).",

--- a/src/internal/whatsappAudioToDiscordNormalization.js
+++ b/src/internal/whatsappAudioToDiscordNormalization.js
@@ -1,0 +1,173 @@
+import childProcess from "node:child_process";
+
+const WHATSAPP_AUDIO_TRANSCODE_TIMEOUT_MS = 20 * 1000;
+
+const normalizeMimeType = (value = "") => {
+	if (typeof value !== "string") return "";
+	return value.split(";")[0].trim().toLowerCase();
+};
+
+const replaceFileExtension = (fileName = "", extension = "mp3") => {
+	const trimmed = typeof fileName === "string" ? fileName.trim() : "";
+	if (!trimmed) return `audio.${extension}`;
+	if (!trimmed.includes(".")) {
+		return `${trimmed}.${extension}`;
+	}
+	return trimmed.replace(/\.[^.]+$/u, `.${extension}`);
+};
+
+const transcodeAudioBufferToMp3 = async (inputBuffer) => {
+	if (!inputBuffer?.length) return null;
+	return await new Promise((resolve, reject) => {
+		const ffmpeg = childProcess.spawn(
+			"ffmpeg",
+			[
+				"-hide_banner",
+				"-loglevel",
+				"error",
+				"-i",
+				"pipe:0",
+				"-vn",
+				"-ac",
+				"1",
+				"-ar",
+				"44100",
+				"-c:a",
+				"libmp3lame",
+				"-b:a",
+				"96k",
+				"-f",
+				"mp3",
+				"pipe:1",
+			],
+			{ stdio: ["pipe", "pipe", "pipe"] },
+		);
+
+		const stdoutChunks = [];
+		const stderrChunks = [];
+		let completed = false;
+		const finish = (err, output = null) => {
+			if (completed) return;
+			completed = true;
+			clearTimeout(timeout);
+			if (err) {
+				reject(err);
+				return;
+			}
+			resolve(output);
+		};
+		const timeout = setTimeout(() => {
+			ffmpeg.kill("SIGKILL");
+			finish(new Error("ffmpeg_timeout"));
+		}, WHATSAPP_AUDIO_TRANSCODE_TIMEOUT_MS);
+
+		ffmpeg.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+		ffmpeg.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+		ffmpeg.on("error", (err) => finish(err));
+		ffmpeg.on("close", (code) => {
+			if (code !== 0) {
+				const stderrText = Buffer.concat(stderrChunks).toString("utf8").trim();
+				finish(
+					new Error(`ffmpeg_exit_${code}${stderrText ? `:${stderrText}` : ""}`),
+				);
+				return;
+			}
+			const output = Buffer.concat(stdoutChunks);
+			if (!output.length) {
+				finish(new Error("ffmpeg_empty_output"));
+				return;
+			}
+			finish(null, output);
+		});
+
+		ffmpeg.stdin.on("error", () => {});
+		ffmpeg.stdin.end(inputBuffer);
+	});
+};
+
+export const createWhatsAppAudioToDiscordFileNormalizer = ({
+	getLogger = null,
+	transcodeBufferToMp3 = transcodeAudioBufferToMp3,
+} = {}) => {
+	let ffmpegMissingLogged = false;
+	const loggerForCall = () =>
+		typeof getLogger === "function" ? getLogger() : getLogger;
+
+	return async ({
+		attachmentBuffer,
+		fileName,
+		mimetype,
+		targetFormat = "original",
+		jid,
+		messageId,
+		maxBytes = 0,
+	} = {}) => {
+		const normalizedMime = normalizeMimeType(mimetype);
+		const normalizedName =
+			typeof fileName === "string" && fileName.trim()
+				? fileName.trim()
+				: "audio.ogg";
+		const fallback = {
+			attachmentBuffer,
+			fileName: normalizedName,
+			contentType: normalizedMime || "audio/ogg",
+			converted: false,
+		};
+
+		if (
+			targetFormat !== "mp3" ||
+			!attachmentBuffer?.length ||
+			!normalizedMime.startsWith("audio/")
+		) {
+			return fallback;
+		}
+
+		const logger = loggerForCall();
+		try {
+			const mp3Buffer = await transcodeBufferToMp3(attachmentBuffer);
+			if (!mp3Buffer?.length) {
+				return fallback;
+			}
+			if (Number.isFinite(maxBytes) && maxBytes > 0 && mp3Buffer.length > maxBytes) {
+				logger?.debug?.(
+					{
+						jid,
+						messageId: messageId || null,
+						fileName: normalizedName,
+						outputBytes: mp3Buffer.length,
+						maxBytes,
+					},
+					"Skipping WhatsApp audio MP3 conversion because output exceeds Discord upload limit",
+				);
+				return fallback;
+			}
+			return {
+				attachmentBuffer: mp3Buffer,
+				fileName: replaceFileExtension(normalizedName, "mp3"),
+				contentType: "audio/mpeg",
+				converted: true,
+			};
+		} catch (err) {
+			if (err?.code === "ENOENT") {
+				if (!ffmpegMissingLogged) {
+					ffmpegMissingLogged = true;
+					logger?.warn?.(
+						"ffmpeg is not installed; WhatsApp audio will be mirrored to Discord without MP3 conversion",
+					);
+				}
+			} else {
+				logger?.debug?.(
+					{
+						err,
+						jid,
+						messageId: messageId || null,
+						fileName: normalizedName,
+					},
+					"Failed to transcode WhatsApp audio to a Discord MP3 attachment",
+				);
+			}
+		}
+
+		return fallback;
+	};
+};

--- a/src/state.js
+++ b/src/state.js
@@ -7,6 +7,7 @@ const state = {
 		DiscordPrefix: false,
 		WAGroupPrefix: false,
 		WASenderPlatformSuffix: false,
+		WhatsAppAudioConversionFormat: "original",
 		DiscordEmbedsToWhatsApp: false,
 		UploadAttachments: true,
 		NewsletterMediaUrlFallback: false,

--- a/src/storage.js
+++ b/src/storage.js
@@ -332,6 +332,9 @@ const storage = {
 					parsed.ThreadNotificationsEnabled,
 				);
 			}
+			if (parsed.WhatsAppAudioConversionFormat !== "mp3") {
+				parsed.WhatsAppAudioConversionFormat = "original";
+			}
 			parsed.ThreadNotificationRoles = normalizeDiscordIdArray(
 				parsed.ThreadNotificationRoles,
 			);

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,7 @@ import {
 	isThreadChatLink,
 } from "./chatLinks.js";
 import { getImageSharp } from "./imageLibs.js";
+import { createWhatsAppAudioToDiscordFileNormalizer } from "./internal/whatsappAudioToDiscordNormalization.js";
 import { createWhatsAppGifToDiscordFileNormalizer } from "./internal/whatsappGifToDiscordNormalization.js";
 import messageStore from "./messageStore.js";
 import state from "./state.js";
@@ -171,6 +172,10 @@ const UPDATE_BUTTON_IDS = {
 const ROLLBACK_BUTTON_ID = "wa2dc:rollback";
 const normalizeWhatsAppGifFileForDiscord =
 	createWhatsAppGifToDiscordFileNormalizer({
+		getLogger: () => state.logger,
+	});
+const normalizeWhatsAppAudioFileForDiscord =
+	createWhatsAppAudioToDiscordFileNormalizer({
 		getLogger: () => state.logger,
 	});
 const resolveLinkPreviewFromContentFn = () => {
@@ -5042,6 +5047,42 @@ const whatsapp = {
 						: normalizedGif.fileName,
 					attachment: normalizedGif.attachmentBuffer,
 					contentType: normalizedGif.contentType,
+					largeFile,
+					downloadCtx: rawMsg,
+					msgType: nMsgType,
+					spoiler: viewOnce,
+				};
+			}
+			if (
+				nMsgType === "audioMessage" &&
+				state.settings.WhatsAppAudioConversionFormat === "mp3"
+			) {
+				const attachmentBuffer = Buffer.from(
+					await downloadMediaMessage(
+						rawMsg,
+						"buffer",
+						{},
+						{
+							logger: state.logger,
+							reuploadRequest: state.waClient.updateMediaMessage,
+						},
+					),
+				);
+				const normalizedAudio = await normalizeWhatsAppAudioFileForDiscord({
+					attachmentBuffer,
+					fileName: baseName,
+					mimetype: msg.mimetype,
+					targetFormat: state.settings.WhatsAppAudioConversionFormat,
+					jid: remoteJid,
+					messageId: this.getId(rawMsg),
+					maxBytes: state.settings.DiscordFileSizeLimit,
+				});
+				return {
+					name: viewOnce
+						? asDiscordSpoilerFileName(normalizedAudio.fileName)
+						: normalizedAudio.fileName,
+					attachment: normalizedAudio.attachmentBuffer,
+					contentType: normalizedAudio.contentType,
 					largeFile,
 					downloadCtx: rawMsg,
 					msgType: nMsgType,

--- a/tests/updateCommands.test.js
+++ b/tests/updateCommands.test.js
@@ -1599,3 +1599,65 @@ test("/setwamediaburstsize updates WhatsApp to Discord media burst size", async 
 		resetClientFactoryOverrides();
 	}
 });
+
+test("/waaudiomp3 toggles WhatsApp audio MP3 conversion", async () => {
+	const originalDiscordUtils = {
+		getGuild: utils.discord.getGuild,
+		getControlChannel: utils.discord.getControlChannel,
+	};
+	const originalSettings = {
+		Token: state.settings.Token,
+		GuildID: state.settings.GuildID,
+		ControlChannelID: state.settings.ControlChannelID,
+		WhatsAppAudioConversionFormat:
+			state.settings.WhatsAppAudioConversionFormat,
+	};
+	const originalDcClient = state.dcClient;
+
+	try {
+		state.settings.Token = "TEST_TOKEN";
+		state.settings.GuildID = "guild";
+		state.settings.ControlChannelID = "control";
+		state.settings.WhatsAppAudioConversionFormat = "original";
+
+		utils.discord.getGuild = async () => ({
+			commands: { set: async () => {} },
+		});
+		utils.discord.getControlChannel = async () => ({ send: async () => {} });
+
+		const fakeClient = new FakeDiscordClient();
+		setClientFactoryOverrides({ createDiscordClient: () => fakeClient });
+		const discordHandler = await importDiscordHandler("wa-audio-mp3");
+		state.dcClient = await discordHandler.start();
+		await delay(0);
+
+		const interaction = createInteraction({
+			channelId: "control",
+			commandName: "waaudiomp3",
+			booleanOptions: {
+				enabled: true,
+			},
+		});
+		fakeClient.emit("interactionCreate", interaction);
+		await delay(0);
+
+		assert.equal(state.settings.WhatsAppAudioConversionFormat, "mp3");
+		assert.equal(interaction.records.editReply.length, 1);
+		assert.equal(
+			interaction.records.editReply[0]?.content,
+			"WhatsApp audio MP3 conversion is enabled. Install ffmpeg on the host for conversion.",
+		);
+	} finally {
+		utils.discord.getGuild = originalDiscordUtils.getGuild;
+		utils.discord.getControlChannel = originalDiscordUtils.getControlChannel;
+
+		state.settings.Token = originalSettings.Token;
+		state.settings.GuildID = originalSettings.GuildID;
+		state.settings.ControlChannelID = originalSettings.ControlChannelID;
+		state.settings.WhatsAppAudioConversionFormat =
+			originalSettings.WhatsAppAudioConversionFormat;
+
+		state.dcClient = originalDcClient;
+		resetClientFactoryOverrides();
+	}
+});

--- a/tests/whatsappAudioToDiscordNormalization.test.js
+++ b/tests/whatsappAudioToDiscordNormalization.test.js
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createWhatsAppAudioToDiscordFileNormalizer } from "../src/internal/whatsappAudioToDiscordNormalization.js";
+
+test("WhatsApp audio normalizer leaves audio unchanged by default", async () => {
+	const normalizeWhatsAppAudioFileForDiscord =
+		createWhatsAppAudioToDiscordFileNormalizer();
+	const sourceBuffer = Buffer.from("ogg-opus-bytes", "utf8");
+	const normalized = await normalizeWhatsAppAudioFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "audio.ogg",
+		mimetype: "audio/ogg; codecs=opus",
+	});
+
+	assert.equal(normalized.converted, false);
+	assert.equal(normalized.fileName, "audio.ogg");
+	assert.equal(normalized.contentType, "audio/ogg");
+	assert.equal(normalized.attachmentBuffer, sourceBuffer);
+});
+
+test("WhatsApp audio normalizer converts opted-in audio buffers into MP3 attachments", async () => {
+	const outputBuffer = Buffer.from("mp3-bytes", "utf8");
+	const normalizeWhatsAppAudioFileForDiscord =
+		createWhatsAppAudioToDiscordFileNormalizer({
+			transcodeBufferToMp3: async (inputBuffer) => {
+				assert.equal(inputBuffer.toString("utf8"), "ogg-opus-bytes");
+				return outputBuffer;
+			},
+		});
+
+	const normalized = await normalizeWhatsAppAudioFileForDiscord({
+		attachmentBuffer: Buffer.from("ogg-opus-bytes", "utf8"),
+		fileName: "audio.ogg",
+		mimetype: "audio/ogg; codecs=opus",
+		targetFormat: "mp3",
+		maxBytes: 1024,
+	});
+
+	assert.equal(normalized.converted, true);
+	assert.equal(normalized.fileName, "audio.mp3");
+	assert.equal(normalized.contentType, "audio/mpeg");
+	assert.equal(normalized.attachmentBuffer, outputBuffer);
+});
+
+test("WhatsApp audio normalizer falls back when MP3 output exceeds the upload limit", async () => {
+	const sourceBuffer = Buffer.from("ogg-opus-bytes", "utf8");
+	const normalizeWhatsAppAudioFileForDiscord =
+		createWhatsAppAudioToDiscordFileNormalizer({
+			getLogger: () => ({ debug() {}, warn() {} }),
+			transcodeBufferToMp3: async () => Buffer.from("too-large", "utf8"),
+		});
+
+	const normalized = await normalizeWhatsAppAudioFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "audio.ogg",
+		mimetype: "audio/ogg",
+		targetFormat: "mp3",
+		maxBytes: 3,
+	});
+
+	assert.equal(normalized.converted, false);
+	assert.equal(normalized.fileName, "audio.ogg");
+	assert.equal(normalized.contentType, "audio/ogg");
+	assert.equal(normalized.attachmentBuffer, sourceBuffer);
+});
+
+test("WhatsApp audio normalizer falls back when ffmpeg is unavailable", async () => {
+	const warnings = [];
+	const normalizeWhatsAppAudioFileForDiscord =
+		createWhatsAppAudioToDiscordFileNormalizer({
+			getLogger: () => ({
+				warn(message) {
+					warnings.push(message);
+				},
+				debug() {},
+			}),
+			transcodeBufferToMp3: async () => {
+				const err = new Error("spawn ffmpeg ENOENT");
+				err.code = "ENOENT";
+				throw err;
+			},
+		});
+	const sourceBuffer = Buffer.from("ogg-opus-bytes", "utf8");
+
+	const first = await normalizeWhatsAppAudioFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "audio.ogg",
+		mimetype: "audio/ogg",
+		targetFormat: "mp3",
+	});
+	const second = await normalizeWhatsAppAudioFileForDiscord({
+		attachmentBuffer: sourceBuffer,
+		fileName: "audio.ogg",
+		mimetype: "audio/ogg",
+		targetFormat: "mp3",
+	});
+
+	assert.equal(first.converted, false);
+	assert.equal(first.fileName, "audio.ogg");
+	assert.equal(first.contentType, "audio/ogg");
+	assert.equal(first.attachmentBuffer, sourceBuffer);
+	assert.equal(second.converted, false);
+	assert.deepEqual(warnings, [
+		"ffmpeg is not installed; WhatsApp audio will be mirrored to Discord without MP3 conversion",
+	]);
+});


### PR DESCRIPTION
Adds a /waaudiomp3 toggle that preserves original WhatsApp audio by default, with optional MP3 conversion for older clients. Includes ffmpeg fallback behavior, persisted setting normalization, tests, and docs.