### PR TITLE
feat: configurable log level via WA2DC_LOG_LEVEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ WA2DC_TOKEN=TOKEN_GO_HERE
 # WA2DC_UPDATE_CHANNEL=stable
 # Optional: keep the previous packaged binary to allow rollbacks
 # WA2DC_KEEP_OLD_BINARY=1
+# Optional: set log verbosity (trace|debug|info|warn|error|fatal|silent, default: info)
+# WA2DC_LOG_LEVEL=info

--- a/docs/dev/runtime-and-layout.md
+++ b/docs/dev/runtime-and-layout.md
@@ -12,6 +12,7 @@ WA2DC bridges WhatsApp and Discord:
 - Discord side: Discord bot (`discord.js`)
 - State: local persistence in `storage/`
 - Process supervision: watchdog runner in `src/runner.js`
+- Runtime logging: `WA2DC_LOG_LEVEL` sets the Pino threshold for both the watchdog and worker loggers. Supported values are `trace`, `debug`, `info`, `warn`, `error`, `fatal`, and `silent`; the default is `info`, and invalid values prevent startup. It controls structured `logs.txt` entries and pretty Pino console output, while raw process warnings or dependency `console` output can still reach `terminal.log`. Debug logs can contain operational identifiers such as WhatsApp JIDs and Discord channel/message IDs, so treat diagnostic logs as sensitive.
 
 Primary flow:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,6 +47,9 @@ Discord stickers are now mirrored as real WhatsApp stickers when possible. Stati
 ## Can I bridge WhatsApp calls to Discord?
 No. The WhatsApp Web protocol used by the bot does not expose the real-time audio or video streams of a call. Incoming and missed calls are only sent as notifications to Discord, so the bot cannot relay or receive live WhatsApp calls.
 
+## How do I change the log verbosity?
+Set the `WA2DC_LOG_LEVEL` environment variable to one of `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `silent` (default: `info`). Setting it to `debug` is useful for diagnosing connection or pairing issues. If you set an invalid value, the bot will fail to start.
+
 ## Is it possible to run on Docker?
 Yes. You can build the image manually or use the provided `docker-compose.yml`. Copy `.env.example` to `.env`, set your Discord token inside and run `docker compose up -d` to start the container.
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import pino from "pino";
 import pretty from "pino-pretty";
 import packageInfo from "../package.json" with { type: "json" };
 import discordHandler from "./discordHandler.js";
+import { resolveLogLevel } from "./logLevel.js";
 import { isRecoverableUnhandledRejection } from "./processErrors.js";
 import state from "./state.js";
 import storage from "./storage.js";
@@ -29,6 +30,7 @@ if (!globalThis.crypto) {
 	];
 	state.logger = pino(
 		{
+			level: resolveLogLevel(),
 			mixin() {
 				return { version };
 			},

--- a/src/logLevel.js
+++ b/src/logLevel.js
@@ -1,0 +1,3 @@
+const resolveLogLevel = () => process.env.WA2DC_LOG_LEVEL || "info";
+
+export { resolveLogLevel };

--- a/src/runner.js
+++ b/src/runner.js
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import pino from "pino";
 import pretty from "pino-pretty";
 
+import { resolveLogLevel } from "./logLevel.js";
 import {
 	consumeRestartFlagSync,
 	createUpdateValidationState,
@@ -59,7 +60,7 @@ async function runWorker() {
 
 function setupSupervisorLogging() {
 	const logger = pino(
-		{},
+		{ level: resolveLogLevel() },
 		pino.multistream([
 			{ stream: pino.destination("logs.txt") },
 			{ stream: pretty({ colorize: true }) },

--- a/tests/logLevel.test.js
+++ b/tests/logLevel.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveLogLevel } from "../src/logLevel.js";
+
+test("resolveLogLevel returns info when WA2DC_LOG_LEVEL is unset", () => {
+	const original = process.env.WA2DC_LOG_LEVEL;
+	delete process.env.WA2DC_LOG_LEVEL;
+	try {
+		assert.equal(resolveLogLevel(), "info");
+	} finally {
+		if (original === undefined) {
+			delete process.env.WA2DC_LOG_LEVEL;
+		} else {
+			process.env.WA2DC_LOG_LEVEL = original;
+		}
+	}
+});
+
+test("resolveLogLevel returns the value of WA2DC_LOG_LEVEL when set", () => {
+	const original = process.env.WA2DC_LOG_LEVEL;
+	process.env.WA2DC_LOG_LEVEL = "debug";
+	try {
+		assert.equal(resolveLogLevel(), "debug");
+	} finally {
+		if (original === undefined) {
+			delete process.env.WA2DC_LOG_LEVEL;
+		} else {
+			process.env.WA2DC_LOG_LEVEL = original;
+		}
+	}
+});


### PR DESCRIPTION
## What
Adds a `WA2DC_LOG_LEVEL` environment variable to control pino log verbosity.

## Why
Both pino loggers (`src/index.js` and the supervisor in `src/runner.js`) are currently constructed without a `level`, so output is hardcoded to pino's default `info` with no way to change it. Self-hosters have no way to turn on `debug` (handy for diagnosing connection/pairing issues) or quiet things down to `warn`.

## How
- New shared helper `src/logLevel.js`: `resolveLogLevel() => process.env.WA2DC_LOG_LEVEL || "info"`
- Wired into both loggers
- Default stays `info`, so behavior is **fully backward-compatible**
- Invalid values make pino throw at startup (fail-loud, no silent fallback)

Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`.

## Docs & tests
- `.env.example`: documented commented line, matching existing style
- `docs/faq.md`: new "How do I change the log verbosity?" entry
- `tests/logLevel.test.js`: covers default + override

Verified locally: `npm run lint` clean (0 warnings), new test passes 2/2.