### PR TITLE
feat: support .env files for standalone binaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,8 @@ This repository currently pins the published npm package `@whiskeysockets/bailey
 
 Start the bot with `npm start` or run the executable from the releases page. The start script watches the process and brings it back up if it crashes. Running `node src/index.js` directly skips this behaviour, so crashes will stop the bot.
 
+Source runs optionally load `.env` from the working directory. Packaged executables load `.env` from the directory containing the executable, which makes the same configuration available when launching a binary directly. Operating-system environment variables take precedence; missing files are ignored. Because `.env` can contain tokens or the database passphrase, restrict it to the runtime account (for example, `chmod 600 .env` on macOS/Linux).
+
 Runtime logs are written to `logs.txt`. Everything printed to the terminal is also saved to `terminal.log`, which can help diagnose issues when running on a headless server.
 
 Alternatively, you can run the bot using Docker. Copy `.env.example` to `.env`, put your Discord bot token in it and execute:

--- a/docs/dev/runtime-and-layout.md
+++ b/docs/dev/runtime-and-layout.md
@@ -12,6 +12,7 @@ WA2DC bridges WhatsApp and Discord:
 - Discord side: Discord bot (`discord.js`)
 - State: local persistence in `storage/`
 - Process supervision: watchdog runner in `src/runner.js`
+- Environment loading: source runs optionally read `.env` from the working directory, while packaged binaries read `.env` beside the executable. Existing operating-system variables take precedence, missing files are ignored, and other read failures stop startup. Loading happens before runtime options and handlers inspect `process.env`.
 - Runtime logging: `WA2DC_LOG_LEVEL` sets the Pino threshold for both the watchdog and worker loggers. Supported values are `trace`, `debug`, `info`, `warn`, `error`, `fatal`, and `silent`; the default is `info`, and invalid values prevent startup. It controls structured `logs.txt` entries and pretty Pino console output, while raw process warnings or dependency `console` output can still reach `terminal.log`. Debug logs can contain operational identifiers such as WhatsApp JIDs and Discord channel/message IDs, so treat diagnostic logs as sensitive.
 
 Primary flow:

--- a/docs/dev/storage-and-side-effects.md
+++ b/docs/dev/storage-and-side-effects.md
@@ -20,6 +20,7 @@ Thread-mode settings such as `DefaultChatType`, `DefaultThreadHostName`, `Thread
 
 The app creates/uses these files in the working directory:
 
+- `.env`: optional startup configuration for source runs; packaged binaries instead look beside the executable
 - `storage/`: persistent bridge/auth state
 - `downloads/`: optional local media download destination
 - `logs.txt`: structured logs (pino)
@@ -37,6 +38,8 @@ If behavior around these files changes, document it here and in user-facing docs
 - Files: `0600`
 
 Never loosen these defaults.
+
+WA2DC does not create or change permissions on `.env`. Operators should restrict it to the runtime account (for example, `chmod 600 .env` on Unix-like systems), because it can contain the Discord token and database passphrase.
 
 Docker note: the official image entrypoint may normalize ownership of mounted `storage/` to `node:node` before startup, then run the app as `node`. This is a container-start side effect and is intended to preserve write access after upgrades from older root-running images.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,6 +56,9 @@ No. The WhatsApp Web protocol used by the bot does not expose the real-time audi
 ## How do I change the log verbosity?
 Set the `WA2DC_LOG_LEVEL` environment variable to one of `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `silent` (default: `info`). Setting it to `debug` is useful for diagnosing connection or pairing issues. If you set an invalid value, the bot will fail to start.
 
+## Can the standalone executable read `.env`?
+Yes. Put `.env` beside the packaged executable and restart it. Source runs read `.env` from the working directory instead. Operating-system environment variables override values from the file, a missing file is ignored, and unreadable files stop startup. The file can contain secrets, so restrict it to the runtime account (for example, `chmod 600 .env` on macOS/Linux) and never share it.
+
 ## Is it possible to run on Docker?
 Yes. You can build the image manually or use the provided `docker-compose.yml`. Copy `.env.example` to `.env`, set your Discord token inside and run `docker compose up -d` to start the container.
 
@@ -70,4 +73,5 @@ The bot is built publicly on [GitHub actions](https://github.com/arespawn/WhatsA
 1. Run `npm run build:bin` to bundle + package for your current OS/CPU (output goes to `build/`)
     - Optional smoke test: `npm run build:bin:smoke`
 1. Keep the generated `runtime/` folder next to the executable. Packaged builds use that sidecar for native modules such as `sharp`.
+1. Optionally copy `.env.example` to `.env` beside the executable. Values set by the operating system take precedence.
 1. That's it. You will have your executable in the `build` folder.

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import "./loadRuntimeEnvironment.js";
+
 import nodeCrypto from "node:crypto";
 import fs from "node:fs";
 import pino from "pino";

--- a/src/loadRuntimeEnvironment.js
+++ b/src/loadRuntimeEnvironment.js
@@ -1,0 +1,3 @@
+import { loadRuntimeEnvironment } from "./runtimeEnvironment.js";
+
+loadRuntimeEnvironment();

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,3 +1,5 @@
+import "./loadRuntimeEnvironment.js";
+
 import { spawn } from "node:child_process";
 import cluster from "node:cluster";
 import fs from "node:fs";

--- a/src/runtimeEnvironment.js
+++ b/src/runtimeEnvironment.js
@@ -1,0 +1,31 @@
+import path from "node:path";
+
+const ENV_FILE_NAME = ".env";
+
+const resolveRuntimeEnvPath = ({
+	cwd = process.cwd(),
+	execPath = process.execPath,
+	isPackaged = Boolean(process.pkg),
+} = {}) => path.join(isPackaged ? path.dirname(execPath) : cwd, ENV_FILE_NAME);
+
+const loadRuntimeEnvironment = ({
+	cwd = process.cwd(),
+	execPath = process.execPath,
+	isPackaged = Boolean(process.pkg),
+	loadEnvFile = process.loadEnvFile,
+} = {}) => {
+	const envFilePath = resolveRuntimeEnvPath({ cwd, execPath, isPackaged });
+	try {
+		loadEnvFile(envFilePath);
+		return { loaded: true, path: envFilePath };
+	} catch (err) {
+		if (err?.code === "ENOENT") {
+			return { loaded: false, path: envFilePath };
+		}
+		throw new Error(`Failed to load WA2DC environment file: ${envFilePath}`, {
+			cause: err,
+		});
+	}
+};
+
+export { loadRuntimeEnvironment, resolveRuntimeEnvPath };

--- a/tests/runtimeEnvironment.test.js
+++ b/tests/runtimeEnvironment.test.js
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+	loadRuntimeEnvironment,
+	resolveRuntimeEnvPath,
+} from "../src/runtimeEnvironment.js";
+
+const restoreEnv = (key, original) => {
+	if (original === undefined) {
+		delete process.env[key];
+		return;
+	}
+	process.env[key] = original;
+};
+
+test("source startup resolves .env from the working directory", () => {
+	const cwd = path.join(os.tmpdir(), "wa2dc-source-root");
+	assert.equal(
+		resolveRuntimeEnvPath({
+			cwd,
+			execPath: path.join(os.tmpdir(), "bin", "node"),
+			isPackaged: false,
+		}),
+		path.join(cwd, ".env"),
+	);
+});
+
+test("packaged startup resolves .env beside the executable", () => {
+	const executable = path.join(os.tmpdir(), "wa2dc-bin", "WA2DC");
+	assert.equal(
+		resolveRuntimeEnvPath({
+			cwd: path.join(os.tmpdir(), "unrelated-working-directory"),
+			execPath: executable,
+			isPackaged: true,
+		}),
+		path.join(path.dirname(executable), ".env"),
+	);
+});
+
+test("runtime .env loads values without overriding the host environment", async () => {
+	const tempDir = await fs.mkdtemp(
+		path.join(os.tmpdir(), "wa2dc-runtime-env-"),
+	);
+	const existingKey = "WA2DC_TEST_ENV_EXISTING";
+	const addedKey = "WA2DC_TEST_ENV_ADDED";
+	const originalExisting = process.env[existingKey];
+	const originalAdded = process.env[addedKey];
+	try {
+		await fs.writeFile(
+			path.join(tempDir, ".env"),
+			`${existingKey}=from-file\n${addedKey}=from-file\n`,
+			{ mode: 0o600 },
+		);
+		process.env[existingKey] = "from-host";
+		delete process.env[addedKey];
+
+		const result = loadRuntimeEnvironment({
+			cwd: tempDir,
+			isPackaged: false,
+		});
+
+		assert.deepEqual(result, {
+			loaded: true,
+			path: path.join(tempDir, ".env"),
+		});
+		assert.equal(process.env[existingKey], "from-host");
+		assert.equal(process.env[addedKey], "from-file");
+	} finally {
+		restoreEnv(existingKey, originalExisting);
+		restoreEnv(addedKey, originalAdded);
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("missing runtime .env is ignored", () => {
+	const missing = new Error("missing");
+	missing.code = "ENOENT";
+	assert.deepEqual(
+		loadRuntimeEnvironment({
+			cwd: path.join(os.tmpdir(), "wa2dc-missing-env"),
+			isPackaged: false,
+			loadEnvFile: () => {
+				throw missing;
+			},
+		}),
+		{
+			loaded: false,
+			path: path.join(os.tmpdir(), "wa2dc-missing-env", ".env"),
+		},
+	);
+});
+
+test("runtime .env read failures stop startup without exposing contents", () => {
+	const denied = new Error("permission denied");
+	denied.code = "EACCES";
+	assert.throws(
+		() =>
+			loadRuntimeEnvironment({
+				cwd: path.join(os.tmpdir(), "wa2dc-denied-env"),
+				isPackaged: false,
+				loadEnvFile: () => {
+					throw denied;
+				},
+			}),
+		(err) => {
+			assert.match(err.message, /Failed to load WA2DC environment file/);
+			assert.equal(err.cause, denied);
+			assert.doesNotMatch(err.message, /permission denied/);
+			return true;
+		},
+	);
+});

--- a/tests/smokeBoot.test.js
+++ b/tests/smokeBoot.test.js
@@ -37,3 +37,33 @@ test("Smoke boots successfully (WA2DC_SMOKE_TEST)", async () => {
 		await fs.rm(tempDir, { recursive: true, force: true });
 	}
 });
+
+test("direct startup loads .env before configuring the worker logger", async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wa2dc-smoke-env-"));
+	try {
+		await fs.writeFile(path.join(tempDir, ".env"), "WA2DC_LOG_LEVEL=silent\n", {
+			mode: 0o600,
+		});
+		const env = { ...process.env, WA2DC_SMOKE_TEST: "1" };
+		delete env.WA2DC_LOG_LEVEL;
+		const result = await runCommand(
+			process.execPath,
+			[path.join(ROOT, "src", "index.js")],
+			{
+				cwd: tempDir,
+				env,
+				timeoutMs: 120_000,
+			},
+		);
+
+		assert.equal(result.code, 0, result.stderr);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		assert.ok(
+			!combined.includes("Smoke test completed successfully."),
+			combined,
+		);
+		await fs.stat(path.join(tempDir, "storage", "wa2dc.sqlite"));
+	} finally {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+});

--- a/tests/smokeRunner.test.js
+++ b/tests/smokeRunner.test.js
@@ -39,3 +39,33 @@ test("Smoke boots successfully via watchdog runner (WA2DC_SMOKE_TEST)", async ()
 		await fs.rm(tempDir, { recursive: true, force: true });
 	}
 });
+
+test("watchdog startup loads .env before configuring its loggers", async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wa2dc-runner-env-"));
+	try {
+		await fs.writeFile(path.join(tempDir, ".env"), "WA2DC_LOG_LEVEL=silent\n", {
+			mode: 0o600,
+		});
+		const env = { ...process.env, WA2DC_SMOKE_TEST: "1" };
+		delete env.WA2DC_LOG_LEVEL;
+		const result = await runCommand(
+			process.execPath,
+			[path.join(ROOT, "src", "runner.js")],
+			{
+				cwd: tempDir,
+				env,
+				timeoutMs: 120_000,
+			},
+		);
+
+		assert.equal(result.code, 0, result.stderr);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		assert.ok(
+			!combined.includes("Smoke test completed successfully."),
+			combined,
+		);
+		await fs.stat(path.join(tempDir, "storage", "wa2dc.sqlite"));
+	} finally {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Adds optional `.env` loading for WA2DC:

- Source runs load `.env` from the working directory
- Packaged binaries load `.env` beside the executable
- Operating-system environment variables take precedence
- Missing files are ignored
- Other read failures stop startup safely

Environment loading happens before loggers, runtime options, and handlers inspect `process.env`.