### PR TITLE
Fix crashes caused by failed link previews

### DIFF
--- a/docs/dev/runtime-and-layout.md
+++ b/docs/dev/runtime-and-layout.md
@@ -57,7 +57,7 @@ Transports and normalization:
 - `src/pollUtils.js`: WhatsApp poll option and encryption-key extraction
 - `src/internal/`: sticker, image, GIF, and audio send/receive normalization
 - `src/utils.js`: transport helpers, mentions, link previews, download server, updater, file delivery, and JID migration helpers
-- `src/processErrors.js` / `src/processExitReporting.js`: recoverable process errors and bounded exit/crash content
+- `src/processErrors.js` / `src/processExitReporting.js`: tightly identified Undici transport failures remain non-fatal across both process error events; other failures retain bounded exit/crash reporting
 
 ## Developer commands
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import pretty from "pino-pretty";
 import packageInfo from "../package.json" with { type: "json" };
 import discordHandler from "./discordHandler.js";
 import { resolveLogLevel } from "./logLevel.js";
-import { isRecoverableUnhandledRejection } from "./processErrors.js";
+import { shouldIgnoreProcessError } from "./processErrors.js";
 import {
 	buildProcessExitReportContent,
 	getProcessExitCode,
@@ -69,11 +69,11 @@ suppressSecretBearingDependencyConsoleLogs();
 	["SIGINT", "SIGTERM", "uncaughtException", "unhandledRejection"].forEach(
 		(eventName) => {
 			process.on(eventName, async (err) => {
-				if (
-					eventName === "unhandledRejection" &&
-					isRecoverableUnhandledRejection(err)
-				) {
-					state.logger.warn({ err }, "Ignoring recoverable network rejection");
+				if (shouldIgnoreProcessError(eventName, err)) {
+					state.logger.warn(
+						{ err, eventName },
+						"Ignoring recoverable Undici network error",
+					);
 					return;
 				}
 				if (shuttingDown) {

--- a/src/processErrors.js
+++ b/src/processErrors.js
@@ -1,4 +1,8 @@
 const MAX_ERROR_CAUSE_DEPTH = 6;
+const RECOVERABLE_PROCESS_EVENTS = new Set([
+	"uncaughtException",
+	"unhandledRejection",
+]);
 const RECOVERABLE_NETWORK_MESSAGE_HINTS = [
 	"terminated",
 	"fetch failed",
@@ -42,7 +46,7 @@ const collectErrorChain = (reason) => {
 const includesHint = (text, hints) =>
 	hints.some((hint) => text.includes(asLower(hint)));
 
-export const isRecoverableUnhandledRejection = (reason) => {
+export const isRecoverableUndiciError = (reason) => {
 	const chain = collectErrorChain(reason);
 	if (!chain.length) {
 		return false;
@@ -59,9 +63,7 @@ export const isRecoverableUnhandledRejection = (reason) => {
 	const looksLikeUndici =
 		stackText.includes("node:internal/deps/undici/undici") ||
 		stackText.includes("/undici/") ||
-		codeText.includes("und_err") ||
-		messageText.includes("fetch failed") ||
-		messageText.includes("terminated");
+		codeText.includes("und_err");
 	if (!looksLikeUndici) {
 		return false;
 	}
@@ -71,3 +73,6 @@ export const isRecoverableUnhandledRejection = (reason) => {
 		includesHint(codeText, RECOVERABLE_NETWORK_CODE_HINTS)
 	);
 };
+
+export const shouldIgnoreProcessError = (eventName, reason) =>
+	RECOVERABLE_PROCESS_EVENTS.has(eventName) && isRecoverableUndiciError(reason);

--- a/src/utils.js
+++ b/src/utils.js
@@ -508,6 +508,14 @@ const readBodyWithLimit = async (body, maxBytes) => {
 	return Buffer.concat(chunks, total);
 };
 
+const discardResponseBody = async (response) => {
+	try {
+		await response?.body?.cancel();
+	} catch (err) {
+		void err;
+	}
+};
+
 const validatePreviewTargetUrl = (candidate = "") => {
 	let url;
 	try {
@@ -560,6 +568,7 @@ const fetchPreviewResponse = async (
 			const status = Number(response.status) || 0;
 			if (status >= 300 && status < 400) {
 				const locationHeader = response.headers.get("location") || "";
+				await discardResponseBody(response);
 				if (!locationHeader) {
 					throw new Error("Redirect without location");
 				}
@@ -576,6 +585,7 @@ const fetchPreviewResponse = async (
 			}
 
 			if (status < 200 || status >= 300) {
+				await discardResponseBody(response);
 				throw new Error(`Unexpected status ${status}`);
 			}
 
@@ -586,6 +596,7 @@ const fetchPreviewResponse = async (
 
 			const contentLength = Number(headers["content-length"]);
 			if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+				await discardResponseBody(response);
 				const err = new Error("Response too large");
 				err.code = "WA2DC_PREVIEW_TOO_LARGE";
 				throw err;
@@ -600,6 +611,8 @@ const fetchPreviewResponse = async (
 			if (treatAsText) {
 				const buffer = await readBodyWithLimit(response.body, maxBytes);
 				data = buffer.toString("utf8");
+			} else {
+				await discardResponseBody(response);
 			}
 
 			return {
@@ -649,6 +662,7 @@ const fetchPreviewBuffer = async (
 			const status = Number(response.status) || 0;
 			if (status >= 300 && status < 400) {
 				const locationHeader = response.headers.get("location") || "";
+				await discardResponseBody(response);
 				if (!locationHeader) {
 					throw new Error("Redirect without location");
 				}
@@ -661,6 +675,7 @@ const fetchPreviewBuffer = async (
 			}
 
 			if (status < 200 || status >= 300) {
+				await discardResponseBody(response);
 				throw new Error(`Unexpected status ${status}`);
 			}
 
@@ -671,6 +686,7 @@ const fetchPreviewBuffer = async (
 
 			const contentLength = Number(headers["content-length"]);
 			if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+				await discardResponseBody(response);
 				const err = new Error("Response too large");
 				err.code = "WA2DC_PREVIEW_TOO_LARGE";
 				throw err;

--- a/tests/processErrors.test.js
+++ b/tests/processErrors.test.js
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isRecoverableUnhandledRejection } from "../src/processErrors.js";
+import {
+	isRecoverableUndiciError,
+	shouldIgnoreProcessError,
+} from "../src/processErrors.js";
 
 test("classifies undici terminated socket close as recoverable", () => {
 	const socketError = new Error("other side closed");
@@ -12,7 +15,10 @@ test("classifies undici terminated socket close as recoverable", () => {
 	reason.stack =
 		"TypeError: terminated\n    at Fetch.onAborted (node:internal/deps/undici/undici:12707:53)";
 
-	assert.equal(isRecoverableUnhandledRejection(reason), true);
+	assert.equal(isRecoverableUndiciError(reason), true);
+	assert.equal(shouldIgnoreProcessError("unhandledRejection", reason), true);
+	assert.equal(shouldIgnoreProcessError("uncaughtException", reason), true);
+	assert.equal(shouldIgnoreProcessError("SIGTERM", reason), false);
 });
 
 test("classifies undici TLS fetch failures as recoverable", () => {
@@ -24,7 +30,16 @@ test("classifies undici TLS fetch failures as recoverable", () => {
 	reason.stack =
 		"TypeError: fetch failed\n    at node:internal/deps/undici/undici:16416:13";
 
-	assert.equal(isRecoverableUnhandledRejection(reason), true);
+	assert.equal(isRecoverableUndiciError(reason), true);
+});
+
+test("does not classify application errors named terminated as recoverable", () => {
+	const reason = new TypeError("terminated");
+	reason.stack =
+		"TypeError: terminated\n    at file:///app/src/handler.js:10:5";
+
+	assert.equal(isRecoverableUndiciError(reason), false);
+	assert.equal(shouldIgnoreProcessError("uncaughtException", reason), false);
 });
 
 test("does not classify generic coding errors as recoverable", () => {
@@ -34,5 +49,5 @@ test("does not classify generic coding errors as recoverable", () => {
 	reason.stack =
 		"TypeError: Cannot read properties of undefined (reading 'x')\n    at file:///app/src/handler.js:10:5";
 
-	assert.equal(isRecoverableUnhandledRejection(reason), false);
+	assert.equal(isRecoverableUndiciError(reason), false);
 });

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -65,15 +65,17 @@ test("Link preview blocks redirects to a different host (e.g., private)", async 
 	const originalFetch = global.fetch;
 	const logger = createLogger();
 	let fetchCalls = 0;
+	let response;
 
 	global.fetch = async () => {
 		fetchCalls += 1;
-		return new Response("", {
+		response = new Response("redirect body", {
 			status: 302,
 			headers: {
 				location: "http://127.0.0.1/private",
 			},
 		});
+		return response;
 	};
 
 	try {
@@ -83,6 +85,7 @@ test("Link preview blocks redirects to a different host (e.g., private)", async 
 		);
 		assert.equal(result, undefined);
 		assert.equal(fetchCalls, 1);
+		assert.equal(response.bodyUsed, true);
 		assert.ok(logger.calls.length >= 1);
 		assert.match(
 			logger.calls[0].payload?.err?.message || "",
@@ -97,16 +100,18 @@ test("Link preview enforces a maximum response size", async () => {
 	const originalFetch = global.fetch;
 	const logger = createLogger();
 	let fetchCalls = 0;
+	let response;
 
 	global.fetch = async () => {
 		fetchCalls += 1;
-		return new Response("", {
+		response = new Response("oversized body", {
 			status: 200,
 			headers: {
 				"content-length": String(1024 * 1024 + 1),
 				"content-type": "text/html",
 			},
 		});
+		return response;
 	};
 
 	try {
@@ -116,8 +121,111 @@ test("Link preview enforces a maximum response size", async () => {
 		);
 		assert.equal(result, undefined);
 		assert.equal(fetchCalls, 1);
+		assert.equal(response.bodyUsed, true);
 		assert.ok(logger.calls.length >= 1);
 		assert.equal(logger.calls[0].payload?.err?.code, "WA2DC_PREVIEW_TOO_LARGE");
+	} finally {
+		global.fetch = originalFetch;
+	}
+});
+
+test("Link preview discards unused error and non-text response bodies", async () => {
+	const originalFetch = global.fetch;
+	const logger = createLogger();
+	const errorResponse = new Response("server error", { status: 503 });
+	const nonTextResponse = new Response("binary body", {
+		status: 200,
+		headers: { "content-type": "application/octet-stream" },
+	});
+	const responses = [errorResponse, nonTextResponse];
+	global.fetch = async () => responses.shift();
+
+	try {
+		assert.equal(
+			await utils.discord.generateLinkPreview("https://example.com/error", {
+				logger,
+			}),
+			undefined,
+		);
+		assert.equal(responses.length, 1);
+		const nonTextResult = await utils.discord.generateLinkPreview(
+			"https://example.com/binary",
+			{
+				logger,
+			},
+		);
+
+		assert.equal(responses.length, 0);
+		assert.equal(
+			nonTextResult?.["canonical-url"],
+			"https://example.com/binary",
+		);
+		assert.equal(errorResponse.bodyUsed, true);
+		assert.equal(nonTextResponse.bodyUsed, true);
+	} finally {
+		global.fetch = originalFetch;
+	}
+});
+
+test("A failed link preview does not disable later previews", async () => {
+	const originalFetch = global.fetch;
+	const logger = createLogger();
+	let fetchCalls = 0;
+	global.fetch = async () => {
+		fetchCalls += 1;
+		if (fetchCalls === 1) {
+			const socketError = new Error("other side closed");
+			socketError.code = "UND_ERR_SOCKET";
+			throw new TypeError("terminated", { cause: socketError });
+		}
+		return new Response(
+			"<html><head><title>Working preview</title></head></html>",
+			{ headers: { "content-type": "text/html" } },
+		);
+	};
+
+	try {
+		const failed = await utils.discord.generateLinkPreview(
+			"https://example.com/first",
+			{ logger },
+		);
+		const recovered = await utils.discord.generateLinkPreview(
+			"https://example.com/second",
+			{ logger },
+		);
+
+		assert.equal(failed, undefined);
+		assert.equal(recovered?.title, "Working preview");
+		assert.equal(fetchCalls, 2);
+	} finally {
+		global.fetch = originalFetch;
+	}
+});
+
+test("An interrupted link preview body fails locally", async () => {
+	const originalFetch = global.fetch;
+	const logger = createLogger();
+	const socketError = new Error("other side closed");
+	socketError.code = "UND_ERR_SOCKET";
+	const terminated = new TypeError("terminated", { cause: socketError });
+	global.fetch = async () =>
+		new Response(
+			new ReadableStream({
+				pull(controller) {
+					controller.error(terminated);
+				},
+			}),
+			{ headers: { "content-type": "text/html" } },
+		);
+
+	try {
+		const result = await utils.discord.generateLinkPreview(
+			"https://example.com/interrupted",
+			{ logger },
+		);
+
+		assert.equal(result, undefined);
+		assert.equal(logger.calls[0]?.payload?.err, terminated);
 	} finally {
 		global.fetch = originalFetch;
 	}

--- a/tests/whatsappBridge.test.js
+++ b/tests/whatsappBridge.test.js
@@ -1344,6 +1344,68 @@ test("Discord to WhatsApp sends include broadcast mode for broadcast chats", asy
 	}
 });
 
+test("Discord link preview failure sends the link and later previews still work", async () => {
+	const harness = await setupWhatsAppHarness({ oneWay: "bidirectional" });
+	try {
+		let previewCalls = 0;
+		utils.whatsapp.generateLinkPreview = async () => {
+			previewCalls += 1;
+			if (previewCalls === 1) {
+				throw new TypeError("terminated");
+			}
+			return { title: "Working preview" };
+		};
+		const emitDiscordMessage = (id, content) =>
+			harness.fakeClient.ev.emit("discordMessage", {
+				jid: "15550002222@s.whatsapp.net",
+				message: {
+					id,
+					content,
+					cleanContent: content,
+					webhookId: null,
+					author: { username: "BridgeUser" },
+					member: { displayName: "BridgeUser" },
+					channel: { send: async () => {} },
+					attachments: new Map(),
+					stickers: new Map(),
+					embeds: [],
+					mentions: {
+						users: new Map(),
+						members: new Map(),
+						roles: new Map(),
+					},
+				},
+			});
+
+		emitDiscordMessage("dc-preview-failed", "https://example.com/first");
+		assert.equal(
+			await waitFor(() => harness.fakeClient.sendCalls.length === 1),
+			true,
+		);
+		emitDiscordMessage("dc-preview-recovered", "https://example.com/second");
+		assert.equal(
+			await waitFor(() => harness.fakeClient.sendCalls.length === 2),
+			true,
+		);
+
+		assert.equal(
+			harness.fakeClient.sendCalls[0]?.content?.text,
+			"https://example.com/first",
+		);
+		assert.equal(
+			harness.fakeClient.sendCalls[0]?.content?.linkPreview,
+			undefined,
+		);
+		assert.equal(
+			harness.fakeClient.sendCalls[1]?.content?.linkPreview?.title,
+			"Working preview",
+		);
+		assert.equal(previewCalls, 2);
+	} finally {
+		harness.cleanup();
+	}
+});
+
 test("Discord raw user and role mentions are converted before forwarding to WhatsApp", async () => {
 	const harness = await setupWhatsAppHarness({ oneWay: "bidirectional" });
 	try {


### PR DESCRIPTION
- Treats confirmed Undici network errors as recoverable
- Safely cleans up unused link preview response bodies
- Sends the original clickable link when its preview fails
- Keeps previews working normally for later messages
- Adds regression tests for the reported socket termination crash