### PR TITLE
chore(release): prepare v2.4.0 with Baileys rc14

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/docs/dev/security-and-privacy.md
+++ b/docs/dev/security-and-privacy.md
@@ -1,7 +1,7 @@
 # Security and Privacy
 
 > Owner: WA2DC maintainers
-> Last reviewed: 2026-07-17
+> Last reviewed: 2026-08-05
 > Scope: Secret handling, logging, network access, local file serving, updates, and authorization boundaries.
 
 WA2DC processes Discord tokens, WhatsApp authentication material, contact identifiers, mirrored content, attachments, message mappings, logs, and operator configuration.
@@ -24,6 +24,7 @@ WA2DC processes Discord tokens, WhatsApp authentication material, contact identi
 ## Network boundaries
 
 - Link-preview fetching must continue to block loopback, private, link-local, and unsafe redirect targets and enforce size/time limits for pages and thumbnails.
+- `link-preview-js` is only used to parse response content that WA2DC has already fetched; do not delegate network fetching to it or bypass WA2DC's URL, DNS/IP, redirect, timeout, and size checks.
 - Signed packaged updates must validate executable and runtime-sidecar signatures before replacement; restore matching backups on partial failure.
 - The local download server defaults to loopback. Binding publicly requires explicit operator configuration; path-safe signed URLs do not replace authentication, firewalling, TLS, expiry, or reverse-proxy controls.
 - Do not introduce new outbound services, analytics, or telemetry without explicit documentation and operator control.

--- a/docs/dev/testing-and-release.md
+++ b/docs/dev/testing-and-release.md
@@ -1,7 +1,7 @@
 # Testing and Release
 
 > Owner: WA2DC maintainers
-> Last reviewed: 2026-07-17
+> Last reviewed: 2026-08-05
 > Scope: Validation commands, documentation checks, CI, bundling, and packaged release constraints.
 
 ## Validation matrix
@@ -42,7 +42,7 @@ Keep these checks dependency-free and network-free. External links are verified 
 
 ## Baileys compatibility
 
-The repository pins a Baileys release and patches it during `postinstall`. Release builds must run after the patch succeeds. Tests must cover each source replacement marker so an upstream package change fails installation visibly rather than producing a partially patched runtime.
+The repository currently pins Baileys `7.0.0-rc14` and patches it during `postinstall`. Release builds must run after the patch succeeds. Tests must cover each source replacement marker so an upstream package change fails installation visibly rather than producing a partially patched runtime.
 
 The current patch set covers:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "wa2dc",
-	"version": "2.4.0-beta.3",
+	"version": "2.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wa2dc",
-			"version": "2.4.0-beta.3",
+			"version": "2.4.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@whiskeysockets/baileys": "7.0.0-rc13",
+				"@whiskeysockets/baileys": "7.0.0-rc14",
 				"canvas": "^3.2.3",
 				"discord.js": "^14.25.1",
 				"jsdom": "^29.1.0",
@@ -20,11 +20,11 @@
 				"pino-pretty": "^13.1.2",
 				"qrcode": "^1.5.3",
 				"sharp": "^0.35.1",
-				"tar": "^7.5.20",
-				"undici": "^7.28.0"
+				"tar": "^7.5.22",
+				"undici": "^7.29.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.4",
+				"@biomejs/biome": "2.5.5",
 				"esbuild": "^0.28.1"
 			},
 			"engines": {
@@ -79,9 +79,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
-			"integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.5.tgz",
+			"integrity": "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -95,20 +95,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.4",
-				"@biomejs/cli-darwin-x64": "2.5.4",
-				"@biomejs/cli-linux-arm64": "2.5.4",
-				"@biomejs/cli-linux-arm64-musl": "2.5.4",
-				"@biomejs/cli-linux-x64": "2.5.4",
-				"@biomejs/cli-linux-x64-musl": "2.5.4",
-				"@biomejs/cli-win32-arm64": "2.5.4",
-				"@biomejs/cli-win32-x64": "2.5.4"
+				"@biomejs/cli-darwin-arm64": "2.5.5",
+				"@biomejs/cli-darwin-x64": "2.5.5",
+				"@biomejs/cli-linux-arm64": "2.5.5",
+				"@biomejs/cli-linux-arm64-musl": "2.5.5",
+				"@biomejs/cli-linux-x64": "2.5.5",
+				"@biomejs/cli-linux-x64-musl": "2.5.5",
+				"@biomejs/cli-win32-arm64": "2.5.5",
+				"@biomejs/cli-win32-x64": "2.5.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
-			"integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.5.tgz",
+			"integrity": "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==",
 			"cpu": [
 				"arm64"
 			],
@@ -123,9 +123,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
-			"integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.5.tgz",
+			"integrity": "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==",
 			"cpu": [
 				"x64"
 			],
@@ -140,16 +140,13 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
-			"integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.5.tgz",
+			"integrity": "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -160,16 +157,13 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
-			"integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.5.tgz",
+			"integrity": "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -180,16 +174,13 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
-			"integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.5.tgz",
+			"integrity": "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -200,16 +191,13 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
-			"integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.5.tgz",
+			"integrity": "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -220,9 +208,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
-			"integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.5.tgz",
+			"integrity": "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==",
 			"cpu": [
 				"arm64"
 			],
@@ -237,9 +225,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
-			"integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.5.tgz",
+			"integrity": "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==",
 			"cpu": [
 				"x64"
 			],
@@ -536,9 +524,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest/node_modules/undici": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
@@ -1760,9 +1748,9 @@
 			}
 		},
 		"node_modules/@whiskeysockets/baileys": {
-			"version": "7.0.0-rc13",
-			"resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc13.tgz",
-			"integrity": "sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA==",
+			"version": "7.0.0-rc14",
+			"resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc14.tgz",
+			"integrity": "sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2280,9 +2268,9 @@
 			}
 		},
 		"node_modules/discord.js/node_modules/undici": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
@@ -3558,9 +3546,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tar": {
-			"version": "7.5.20",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-			"integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+			"version": "7.5.22",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -3725,9 +3713,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wa2dc",
-	"version": "2.4.0-beta.3",
+	"version": "2.4.0",
 	"description": "WhatsAppToDiscord is a Discord bot that uses WhatsApp Web as a bridge between Discord and WhatsApp",
 	"type": "module",
 	"main": "src/runner.js",
@@ -37,7 +37,7 @@
 		"node": ">=24"
 	},
 	"dependencies": {
-		"@whiskeysockets/baileys": "7.0.0-rc13",
+		"@whiskeysockets/baileys": "7.0.0-rc14",
 		"canvas": "^3.2.3",
 		"discord.js": "^14.25.1",
 		"jsdom": "^29.1.0",
@@ -47,11 +47,11 @@
 		"pino-pretty": "^13.1.2",
 		"qrcode": "^1.5.3",
 		"sharp": "^0.35.1",
-		"tar": "^7.5.20",
-		"undici": "^7.28.0"
+		"tar": "^7.5.22",
+		"undici": "^7.29.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.4",
+		"@biomejs/biome": "2.5.5",
 		"esbuild": "^0.28.1"
 	},
 	"pkg": {},
@@ -67,10 +67,10 @@
 			"file-type": "21.3.3"
 		},
 		"discord.js": {
-			"undici": "6.27.0"
+			"undici": "6.28.0"
 		},
 		"@discordjs/rest": {
-			"undici": "6.27.0"
+			"undici": "6.28.0"
 		},
 		"sharp": {
 			"tar-fs": "3.1.1"

--- a/scripts/patchBaileysAndroidBrowser.js
+++ b/scripts/patchBaileysAndroidBrowser.js
@@ -460,9 +460,9 @@ const main = async () => {
 	const packageJson = JSON.parse(
 		await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
 	);
-	if (packageJson.version !== "7.0.0-rc13") {
+	if (packageJson.version !== "7.0.0-rc14") {
 		throw new Error(
-			`Baileys Android browser patch expects 7.0.0-rc13, found ${packageJson.version}`,
+			`Baileys Android browser patch expects 7.0.0-rc14, found ${packageJson.version}`,
 		);
 	}
 

--- a/tests/baileysAndroidBrowserPatch.test.js
+++ b/tests/baileysAndroidBrowserPatch.test.js
@@ -5,7 +5,7 @@ import test from "node:test";
 import { Browsers, proto } from "@whiskeysockets/baileys";
 import { generateLoginNode } from "@whiskeysockets/baileys/lib/Utils/validate-connection.js";
 
-test("Baileys rc13 carries WA2DC Android browser patch", () => {
+test("Baileys rc14 carries WA2DC Android browser patch", () => {
 	assert.equal(typeof Browsers.android, "function");
 	assert.deepEqual(Browsers.android("13"), ["13", "Android", ""]);
 
@@ -22,7 +22,7 @@ test("Baileys rc13 carries WA2DC Android browser patch", () => {
 	);
 });
 
-test("Baileys rc13 waits for initial sync on reconnects", () => {
+test("Baileys rc14 waits for initial sync on reconnects", () => {
 	const chatsSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/chats.js",
 		"utf8",
@@ -38,7 +38,7 @@ test("Baileys rc13 waits for initial sync on reconnects", () => {
 	);
 });
 
-test("Baileys rc13 skips startup buffering when history sync is disabled", () => {
+test("Baileys rc14 skips startup buffering when history sync is disabled", () => {
 	const socketSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/socket.js",
 		"utf8",
@@ -72,7 +72,7 @@ test("Baileys rc13 skips startup buffering when history sync is disabled", () =>
 	assert.doesNotMatch(chatsSource, /setTimeout\(\(\) => ev\.flush\(\), 0\)/u);
 });
 
-test("Baileys rc13 logs summarized own LID migration probes", () => {
+test("Baileys rc14 logs summarized own LID migration probes", () => {
 	const socketSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/socket.js",
 		"utf8",
@@ -88,7 +88,7 @@ test("Baileys rc13 logs summarized own LID migration probes", () => {
 	);
 });
 
-test("Baileys rc13 tctoken prune is bounded during startup", () => {
+test("Baileys rc14 tctoken prune is bounded during startup", () => {
 	const messagesRecvSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js",
 		"utf8",
@@ -107,7 +107,7 @@ test("Baileys rc13 tctoken prune is bounded during startup", () => {
 	);
 });
 
-test("Baileys rc13 preserves delivered receipts while WA2DC stays unavailable", () => {
+test("Baileys rc14 preserves delivered receipts while WA2DC stays unavailable", () => {
 	const messagesRecvSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js",
 		"utf8",
@@ -127,7 +127,7 @@ test("Baileys rc13 preserves delivered receipts while WA2DC stays unavailable", 
 	);
 });
 
-test("Baileys rc13 notification ack tolerates pre-auth pairing notifications", () => {
+test("Baileys rc14 notification ack tolerates pre-auth pairing notifications", () => {
 	const messagesRecvSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js",
 		"utf8",
@@ -143,7 +143,7 @@ test("Baileys rc13 notification ack tolerates pre-auth pairing notifications", (
 	);
 });
 
-test("Baileys rc13 skips incomplete link code pairing notifications safely", () => {
+test("Baileys rc14 skips incomplete link code pairing notifications safely", () => {
 	const messagesRecvSource = fs.readFileSync(
 		"node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js",
 		"utf8",


### PR DESCRIPTION
- bump WA2DC to 2.4.0
- upgrade Baileys to rc14 and revalidate patches
- update Undici, tar, and Biome
- refresh compatibility tests and security documentation