### PR TITLE
fix: allow validation of draft releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,8 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "fix"
-      include: "scope"
+      prefix: "fix(deps)"
+      prefix-development: "fix(deps)"
     ignore:
       - dependency-name: "discord.js"
       - dependency-name: "undici"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
     if: always() && (needs.release_please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      # Draft releases are only visible to tokens with push-level contents access.
+      contents: write
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       sha: ${{ steps.release.outputs.sha }}

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -176,10 +176,21 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 		path.join(ROOT, ".github/workflows/release.yml"),
 		"utf8",
 	);
+	const dependabot = await fs.readFile(
+		path.join(ROOT, ".github/dependabot.yml"),
+		"utf8",
+	);
 	assert.match(ci, /branches: \[main, next\]/u);
 	assert.match(ci, /scripts\/validatePrTitle\.js/u);
 	assert.match(release, /workflow_dispatch:/u);
 	assert.match(release, /ubuntu-24\.04-arm/u);
+	assert.match(
+		release,
+		/resolve:\r?\n[\s\S]*?permissions:\r?\n\s+# Draft releases[^\r\n]*\r?\n\s+contents: write/u,
+	);
+	assert.match(dependabot, /prefix: "fix\(deps\)"/u);
+	assert.match(dependabot, /prefix-development: "fix\(deps\)"/u);
+	assert.doesNotMatch(dependabot, /include: "scope"/u);
 	for (const binary of [
 		"WA2DC-Linux",
 		"WA2DC-Linux-arm64",


### PR DESCRIPTION
## Summary

- let the resolver inspect hidden draft releases using the minimum GitHub permission that exposes them
- keep all build, signing, Docker, and publish jobs blocked until draft validation succeeds
- force Dependabot npm titles to use fix(deps) for both production and development updates
- add regression coverage for both configurations

## Verification

- node --test tests/releaseAutomation.test.js
- npm run check

## Recovery

After merge, manually resume the existing hidden v2.5.0-beta.1 draft using the release workflow's recovery input.