### PR TITLE
fix: run recovered release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ inputs.tag || github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && (contains(inputs.tag, '-beta.') && 'next' || 'main') || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
 
   resolve:
     needs: release_please
-    if: always() && (needs.release_please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
+    if: ${{ !cancelled() && (needs.release_please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-24.04
     permissions:
       # Draft releases are only visible to tokens with push-level contents access.
@@ -84,6 +84,10 @@ jobs:
             channel="stable"
             branch="main"
           fi
+          if [[ "$GITHUB_REF_NAME" != "$branch" ]]; then
+            echo "Recovery for $tag must be dispatched from $branch, not $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
           git fetch origin "$branch" --no-tags
           git merge-base --is-ancestor "$sha" "origin/$branch"
           published_releases="$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --limit 100 --json tagName,isPrerelease)"
@@ -116,7 +120,7 @@ jobs:
 
   verify:
     needs: resolve
-    if: always() && needs.resolve.result == 'success'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -140,7 +144,7 @@ jobs:
 
   build:
     needs: [resolve, verify]
-    if: always() && needs.resolve.result == 'success' && needs.verify.result == 'success'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.verify.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +182,7 @@ jobs:
 
   sign:
     needs: [resolve, build]
-    if: always() && needs.resolve.result == 'success' && needs.build.result == 'success'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.build.result == 'success' }}
     runs-on: ubuntu-24.04
     environment: release-signing
     permissions:
@@ -217,7 +221,7 @@ jobs:
 
   docker:
     needs: [resolve, sign]
-    if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.sign.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -263,7 +267,7 @@ jobs:
 
   publish:
     needs: [resolve, sign, docker]
-    if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -283,7 +287,7 @@ jobs:
 
   sync_next:
     needs: [resolve, publish]
-    if: always() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable'
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
 
   verify:
     needs: resolve
+    if: always() && needs.resolve.result == 'success'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -139,6 +140,7 @@ jobs:
 
   build:
     needs: [resolve, verify]
+    if: always() && needs.resolve.result == 'success' && needs.verify.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +178,7 @@ jobs:
 
   sign:
     needs: [resolve, build]
+    if: always() && needs.resolve.result == 'success' && needs.build.result == 'success'
     runs-on: ubuntu-24.04
     environment: release-signing
     permissions:
@@ -214,6 +217,7 @@ jobs:
 
   docker:
     needs: [resolve, sign]
+    if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -259,6 +263,7 @@ jobs:
 
   publish:
     needs: [resolve, sign, docker]
+    if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -278,7 +283,7 @@ jobs:
 
   sync_next:
     needs: [resolve, publish]
-    if: needs.resolve.outputs.channel == 'stable'
+    if: always() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -188,15 +188,25 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 		release,
 		/resolve:\r?\n[\s\S]*?permissions:\r?\n\s+# Draft releases[^\r\n]*\r?\n\s+contents: write/u,
 	);
-	for (const condition of [
-		"if: always() && needs.resolve.result == 'success'",
-		"if: always() && needs.resolve.result == 'success' && needs.verify.result == 'success'",
-		"if: always() && needs.resolve.result == 'success' && needs.build.result == 'success'",
-		"if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success'",
-		"if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success'",
-		"if: always() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable'",
+	const normalizedRelease = release
+		.replaceAll("\r\n", "\n")
+		.replaceAll(/\$\{\{/gu, "<EXPR>");
+	assert.ok(
+		normalizedRelease.includes(
+			"group: release-<EXPR> github.event_name == 'workflow_dispatch' && (contains(inputs.tag, '-beta.') && 'next' || 'main') || github.ref_name }}",
+		),
+	);
+	assert.match(normalizedRelease, /GITHUB_REF_NAME.*branch/u);
+	for (const snippet of [
+		"  resolve:\n    needs: release_please\n    if: <EXPR> !cancelled() && (needs.release_please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}",
+		"  verify:\n    needs: resolve\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' }}",
+		"  build:\n    needs: [resolve, verify]\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' && needs.verify.result == 'success' }}",
+		"  sign:\n    needs: [resolve, build]\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' && needs.build.result == 'success' }}",
+		"  docker:\n    needs: [resolve, sign]\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' && needs.sign.result == 'success' }}",
+		"  publish:\n    needs: [resolve, sign, docker]\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success' }}",
+		"  sync_next:\n    needs: [resolve, publish]\n    if: <EXPR> !cancelled() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable' }}",
 	]) {
-		assert.ok(release.includes(condition), condition);
+		assert.ok(normalizedRelease.includes(snippet), snippet);
 	}
 	assert.match(dependabot, /prefix: "fix\(deps\)"/u);
 	assert.match(dependabot, /prefix-development: "fix\(deps\)"/u);

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -188,6 +188,16 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 		release,
 		/resolve:\r?\n[\s\S]*?permissions:\r?\n\s+# Draft releases[^\r\n]*\r?\n\s+contents: write/u,
 	);
+	for (const condition of [
+		"if: always() && needs.resolve.result == 'success'",
+		"if: always() && needs.resolve.result == 'success' && needs.verify.result == 'success'",
+		"if: always() && needs.resolve.result == 'success' && needs.build.result == 'success'",
+		"if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success'",
+		"if: always() && needs.resolve.result == 'success' && needs.sign.result == 'success' && needs.docker.result == 'success'",
+		"if: always() && needs.resolve.result == 'success' && needs.publish.result == 'success' && needs.resolve.outputs.channel == 'stable'",
+	]) {
+		assert.ok(release.includes(condition), condition);
+	}
 	assert.match(dependabot, /prefix: "fix\(deps\)"/u);
 	assert.match(dependabot, /prefix-development: "fix\(deps\)"/u);
 	assert.doesNotMatch(dependabot, /include: "scope"/u);


### PR DESCRIPTION
## Summary

- make manual recovery continue after the intentionally skipped Release Please job
- require each downstream job's direct prerequisites to have succeeded
- preserve fail-closed behavior for validation, native builds, signing, Docker publication, and release publication
- cover every recovery job condition in the workflow regression test

## Verification

- node --test tests/releaseAutomation.test.js
- npm run check

## Recovery

After merge, rerun the existing hidden v2.5.0-beta.1 draft through workflow_dispatch.