### PR TITLE
fix(deps): route automated updates through next

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -15,8 +16,8 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "fix"
-      include: "scope"
+      prefix: "fix(deps)"
+      prefix-development: "fix(deps)"
     ignore:
       - dependency-name: "discord.js"
       - dependency-name: "undici"
@@ -31,6 +32,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -45,7 +47,7 @@ updates:
       - "dependencies"
       - "github_actions"
     commit-message:
-      prefix: "ci"
+      prefix: "fix(deps)"
     groups:
       actions-minor-patch:
         patterns:

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -176,10 +176,24 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 		path.join(ROOT, ".github/workflows/release.yml"),
 		"utf8",
 	);
+	const dependabot = await fs.readFile(
+		path.join(ROOT, ".github/dependabot.yml"),
+		"utf8",
+	);
 	assert.match(ci, /branches: \[main, next\]/u);
 	assert.match(ci, /scripts\/validatePrTitle\.js/u);
 	assert.match(release, /workflow_dispatch:/u);
 	assert.match(release, /ubuntu-24\.04-arm/u);
+	assert.equal(
+		[...dependabot.matchAll(/^\s+target-branch: "next"$/gmu)].length,
+		2,
+	);
+	assert.equal(
+		[...dependabot.matchAll(/^\s+prefix: "fix\(deps\)"$/gmu)].length,
+		2,
+	);
+	assert.match(dependabot, /prefix-development: "fix\(deps\)"/u);
+	assert.doesNotMatch(dependabot, /include: "scope"/u);
 	for (const binary of [
 		"WA2DC-Linux",
 		"WA2DC-Linux-arm64",


### PR DESCRIPTION
## Summary

- route npm and GitHub Actions Dependabot pull requests to `next`
- use the release-driving `fix(deps)` prefix for accepted updates
- add regression coverage for both Dependabot update stanzas

## Verification

- npm run check
- node --test tests/releaseAutomation.test.js
- npm test (560 tests: 558 passed, 2 skipped)