### PR TITLE
fix(deps): route automated updates through next

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -31,6 +32,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -45,7 +47,7 @@ updates:
       - "dependencies"
       - "github_actions"
     commit-message:
-      prefix: "ci"
+      prefix: "fix(deps)"
     groups:
       actions-minor-patch:
         patterns:

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -208,7 +208,14 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 	]) {
 		assert.ok(normalizedRelease.includes(snippet), snippet);
 	}
-	assert.match(dependabot, /prefix: "fix\(deps\)"/u);
+	assert.equal(
+		[...dependabot.matchAll(/^\s+target-branch: "next"$/gmu)].length,
+		2,
+	);
+	assert.equal(
+		[...dependabot.matchAll(/^\s+prefix: "fix\(deps\)"$/gmu)].length,
+		2,
+	);
 	assert.match(dependabot, /prefix-development: "fix\(deps\)"/u);
 	assert.doesNotMatch(dependabot, /include: "scope"/u);
 	for (const binary of [


### PR DESCRIPTION
## Summary

- keep the `next` branch copy of Dependabot policy aligned with `main`
- route npm and GitHub Actions Dependabot pull requests to `next`
- use the release-driving `fix(deps)` prefix for accepted updates

## Verification

- npm run check
- node --test tests/releaseAutomation.test.js
- npm test (560 tests: 558 passed, 2 skipped)