### PR TITLE
docs: clarify final beta synchronization order

### DIFF
--- a/docs/dev/testing-and-release.md
+++ b/docs/dev/testing-and-release.md
@@ -26,7 +26,7 @@ The `CI` workflow runs for pull requests and pushes to `main` and `next`. It val
 - Release Please PRs own `package.json`, `package-lock.json`, `CHANGELOG.md`, and the release manifest version. Do not hand-edit versions during an ordinary release.
 - `feat` is minor; `fix`, `fix(deps)`, `perf`, and `revert` are patch; `!` or `BREAKING CHANGE` is major. Maintenance-only `docs`, `test`, `ci`, `build`, and `chore` commits do not independently release.
 
-Promotion CI requires the published beta tag to resolve to `next` HEAD and requires its signed update-manifest assets. This proves there are no commits after the tested beta. After stable publication, the GitHub App opens a `main` to `next` synchronization PR.
+Promotion CI requires the published beta tag to resolve to `next` HEAD and requires its signed update-manifest assets. This proves there are no commits after the tested beta. If `main` changed independently, synchronize it into `next` before publishing the final beta; a reconciliation after beta publication requires a new beta, forced with a `Release-As: X.Y.Z-beta.N` commit footer when it has no independently releasable changes. After stable publication, the GitHub App opens a `main` to `next` synchronization PR.
 
 ## Automated release pipeline
 


### PR DESCRIPTION
## Summary

- document that independent main changes must be synchronized before the final beta
- retain the exact-tag promotion invariant
- force v2.5.0-beta.3 for the already reconciled next head

## Verification

- npm run docs:check
- npm run check