### PR TITLE
fix: harden stable promotion automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         shell: bash
         run: |
           version="$(node -p "require('./package.json').version")"
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
             echo "next must be promoted from a beta release commit; found $version" >&2
+            exit 1
+          fi
+          stable_version="${version%%-beta.*}"
+          if ! grep -Fqx "Release-As: $stable_version" <<<"$PR_BODY"; then
+            echo "promotion PR body must contain an exact Release-As: $stable_version line" >&2
             exit 1
           fi
           tag="v$version"
@@ -100,6 +106,16 @@ jobs:
             echo "$tag does not point to next HEAD ($HEAD_SHA)" >&2
             exit 1
           fi
-          release_json="$(gh release view "$tag" --json isDraft,isPrerelease,assets)"
-          jq -e '.isDraft == false and .isPrerelease == true' <<<"$release_json" >/dev/null
+          release_json=""
+          for attempt in {1..60}; do
+            if release_json="$(gh release view "$tag" --json isDraft,isPrerelease,assets 2>/dev/null)" \
+              && jq -e '.isDraft == false and .isPrerelease == true' <<<"$release_json" >/dev/null; then
+              break
+            fi
+            if [[ "$attempt" -eq 60 ]]; then
+              echo "$tag was not published as a prerelease within 10 minutes" >&2
+              exit 1
+            fi
+            sleep 10
+          done
           jq -e '[.assets[].name] | index("update-manifest.json") and index("update-manifest.json.sig")' <<<"$release_json" >/dev/null

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,11 @@ Dependabot pull requests remain human-reviewed. Their accepted npm updates use `
 1. Merge reviewed work into `next` with squash merge.
 2. Release Please maintains a beta release PR on `next`, including the version and `CHANGELOG.md`.
 3. Merging that PR starts the fail-closed native build, signing, container, and draft-release pipeline. A successful run publishes `vX.Y.Z-beta.N` and moves the `unstable` container tag.
-4. Test the published beta. When it is ready, open a `next` to `main` pull request and merge it with a merge commit. Promotion CI requires `next` HEAD to be the published beta tag and to contain the signed update-manifest assets, so additional unreleased changes cannot be promoted accidentally.
+4. Test the published beta. When it is ready, open a `next` to `main` pull request with a `chore: promote ...` title and an exact `Release-As: X.Y.Z` line in its body, then merge it with a merge commit. Promotion CI requires the footer, requires `next` HEAD to be the published beta tag, and waits for its signed update-manifest assets, so an unpublished beta or additional unreleased changes cannot be promoted accidentally.
 5. Release Please maintains the stable release PR on `main`. Merging it publishes `vX.Y.Z`, `stable`, and `latest` only after all release jobs succeed.
 6. The release GitHub App opens a `main` to `next` synchronization PR. Merge it before starting the next beta cycle.
 
-Do not squash the `next` to `main` promotion PR: its constituent commits are the stable changelog input. Beta is the only prerelease phase; do not create automated alpha or release-candidate tags.
+Configure GitHub's default merge-commit title and message as the pull-request title and body so Release Please receives the required `Release-As` footer. Do not squash the `next` to `main` promotion PR: its constituent commits are the stable changelog input. Beta is the only prerelease phase; do not create automated alpha or release-candidate tags.
 
 ## Local validation
 

--- a/docs/dev/testing-and-release.md
+++ b/docs/dev/testing-and-release.md
@@ -26,7 +26,7 @@ The `CI` workflow runs for pull requests and pushes to `main` and `next`. It val
 - Release Please PRs own `package.json`, `package-lock.json`, `CHANGELOG.md`, and the release manifest version. Do not hand-edit versions during an ordinary release.
 - `feat` is minor; `fix`, `fix(deps)`, `perf`, and `revert` are patch; `!` or `BREAKING CHANGE` is major. Maintenance-only `docs`, `test`, `ci`, `build`, and `chore` commits do not independently release.
 
-Promotion CI requires the published beta tag to resolve to `next` HEAD and requires its signed update-manifest assets. This proves there are no commits after the tested beta. If `main` changed independently, synchronize it into `next` before publishing the final beta; a reconciliation after beta publication requires a new beta, forced with a `Release-As: X.Y.Z-beta.N` commit footer when it has no independently releasable changes. After stable publication, the GitHub App opens a `main` to `next` synchronization PR.
+Promotion CI requires the published beta tag to resolve to `next` HEAD and requires its signed update-manifest assets. The gate waits up to 10 minutes for the fail-closed release pipeline to publish the beta, avoiding a race between the release and promotion workflows. The promotion pull-request body must contain an exact `Release-As: X.Y.Z` line matching the beta version without its suffix; GitHub must use the pull-request title and body as the merge-commit title and message so Release Please prepares that stable version. Together these checks prove there are no commits after the tested beta and make the stable transition deterministic. If `main` changed independently, synchronize it into `next` before publishing the final beta; a reconciliation after beta publication requires a new beta, forced with a `Release-As: X.Y.Z-beta.N` commit footer when it has no independently releasable changes. After stable publication, the GitHub App opens a `main` to `next` synchronization PR.
 
 ## Automated release pipeline
 
@@ -53,7 +53,7 @@ Before enabling the workflow in GitHub:
 1. Create a repository-scoped GitHub App with Contents, Pull requests, and Issues read/write access, install it only on this repository, set its ID as the `RELEASE_APP_ID` repository variable, and store its private key as the `RELEASE_APP_PRIVATE_KEY` repository secret.
 2. Create the protected `release-signing` environment and store the existing RSA private key as its `SIGN_KEY` secret. Restrict environment deployment to `main` and `next`; require maintainer approval if the repository's threat model needs it.
 3. Merge the automation to `main`, create `next` from that exact commit, and protect both branches. Require `CI` checks, one or more reviews, resolved conversations, and block ordinary direct pushes. Allow the installed release App only where automation needs it.
-4. Enable squash merge for normal work into `next` and merge commits for the `next` to `main` promotion PR.
+4. Enable squash merge for normal work into `next` and merge commits for the `next` to `main` promotion PR. Configure merge-commit titles from the pull-request title and merge-commit messages from the pull-request body so the validated stable `Release-As` footer reaches Release Please.
 5. Publish and exercise `v2.5.0-beta.1`, including `/update` and rollback on each packaged target. Promote only after those checks pass.
 
 ## Documentation checks

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -182,6 +182,10 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 	);
 	assert.match(ci, /branches: \[main, next\]/u);
 	assert.match(ci, /scripts\/validatePrTitle\.js/u);
+	assert.match(ci, /PR_BODY:.*pull_request\.body/u);
+	assert.match(ci, /Release-As: \$stable_version/u);
+	assert.match(ci, /for attempt in \{1\.\.60\}/u);
+	assert.match(ci, /sleep 10/u);
 	assert.match(release, /workflow_dispatch:/u);
 	assert.match(release, /ubuntu-24\.04-arm/u);
 	assert.match(


### PR DESCRIPTION
## Summary

- wait for the final beta release to become public before promotion CI evaluates its assets
- require the promotion PR to carry the stable Release-As footer
- preserve PR titles and bodies in GitHub merge commits so Release Please creates the stable release deterministically
- document and test the strengthened promotion contract

## Verification

- npm run check
- npm run docs:check
- node --test tests/releaseAutomation.test.js

Release-As: 2.5.0