### PR TITLE
fix: bound graceful shutdown and watchdog exit

### DIFF
--- a/docs/dev/runtime-and-layout.md
+++ b/docs/dev/runtime-and-layout.md
@@ -1,7 +1,7 @@
 # Runtime and Layout
 
 > Owner: WA2DC maintainers
-> Last reviewed: 2026-07-17
+> Last reviewed: 2026-08-29
 > Scope: Process lifecycle, startup invariants, module ownership, and packaged runtime behavior.
 
 ## Process model
@@ -14,6 +14,10 @@ Normal source and packaged startup uses the watchdog:
 2. `src/index.js` initializes SQLite-backed app/auth state, handlers, autosave, and crash reporting.
 3. `src/discordHandler.js` and `src/whatsappHandler.js` connect the transports and register bridge events.
 4. The runner handles explicit restart flags, bounded crash restarts, exponential backoff, and packaged post-update rollback validation.
+
+`SIGINT` and `SIGTERM` use a bounded graceful-shutdown path. The watchdog requests shutdown over a validated internal IPC message, including on Windows where forwarding these POSIX signal names to a child can terminate it abruptly. The worker first blocks reconnect work, independently quiesces the download server and WhatsApp ingress, and, once startup hydration is complete, saves local state. It then makes a time-limited report attempt while Discord remains available, destroys Discord, saves again, and closes SQLite last. Each stage is bounded so a stuck transport cannot prevent the final persistence stages. A matching OS-signal/IPC copy delivered to the worker is coalesced briefly; two direct OS signals still force an immediate exit. The watchdog waits for the real worker exit event after graceful shutdown and after `SIGKILL`, using a short final deadline only if the child exit event never arrives.
+
+Queued crash-report delivery runs in the background after Discord startup so a slow Discord request cannot delay WhatsApp startup or QR generation. New fatal reports are atomically written directly to unique private `crash-report.pending-*.txt` spool files, so consecutive failures cannot overwrite one another or a legacy canonical `crash-report.txt`. Startup atomically claims any canonical report into the same spool. Success removes only the owned pending file, while failure leaves it for the next startup.
 
 The official Docker entrypoint starts `src/index.js` directly and relies on the container restart policy rather than nesting the watchdog inside the container.
 
@@ -57,7 +61,7 @@ Transports and normalization:
 - `src/pollUtils.js`: WhatsApp poll option and encryption-key extraction
 - `src/internal/`: sticker, image, GIF, and audio send/receive normalization
 - `src/utils.js`: transport helpers, mentions, link previews, download server, updater, file delivery, and JID migration helpers
-- `src/processErrors.js` / `src/processExitReporting.js`: tightly identified Undici transport failures remain non-fatal across both process error events; other failures retain bounded exit/crash reporting
+- `src/processErrors.js` / `src/processExitReporting.js` / `src/shutdown.js`: tightly identified Undici transport failures remain non-fatal across both process error events; other failures retain bounded exit/crash reporting, cleanup, and watchdog escalation
 
 ## Developer commands
 
@@ -72,6 +76,7 @@ Transports and normalization:
 - Local packaged build: `npm run build:bin`
 - Packaged build and smoke: `npm run build:bin:smoke`
 - Worker smoke: `WA2DC_SMOKE_TEST=1 node src/index.js`
+- Signal smoke: `WA2DC_SMOKE_TEST=1 WA2DC_SMOKE_WAIT_FOR_SIGNAL=1 node src/runner.js`, then send `SIGINT`
 
 ## Packaged runtime model
 

--- a/docs/dev/storage-and-side-effects.md
+++ b/docs/dev/storage-and-side-effects.md
@@ -1,7 +1,7 @@
 # Storage and Side Effects
 
 > Owner: WA2DC maintainers
-> Last reviewed: 2026-07-17
+> Last reviewed: 2026-08-29
 > Scope: SQLite contracts, runtime artifacts, lifetimes, and explicit filesystem-permission enforcement.
 
 ## SQLite persistence contract
@@ -20,6 +20,8 @@ Table responsibilities:
 
 SQLite may create `wa2dc.sqlite-wal` and `wa2dc.sqlite-shm` while running. Stop WA2DC before filesystem-level backup so the copied database is consistent; copy the complete `storage/` directory rather than selecting individual files.
 
+On `SIGINT` or `SIGTERM`, WA2DC blocks reconnect work, independently quiesces download and WhatsApp ingress, and saves current app state before attempting its bounded Discord shutdown report. It then destroys Discord, saves once more, and closes SQLite last. Every stage has a deadline, so a stuck transport cannot prevent the final save/close attempt; operators should continue to stop WA2DC normally before copying storage.
+
 ## Encryption behavior
 
 `WA2DC_DB_PASSPHRASE` enables encryption of stored payload values when present at first database creation. The metadata needed to identify/derive the encrypted format remains readable. Setting a passphrase for an existing unencrypted database is ignored rather than silently converting it.
@@ -35,7 +37,8 @@ Working-directory artifacts:
 - `downloads/`: optional large-media destination and pruning target
 - `logs.txt`: structured Pino logs from worker and/or watchdog
 - `terminal.log`: watchdog tee of worker stdout/stderr; absent when no watchdog is used
-- `crash-report.txt`: fallback crash report consumed and removed after it can be posted to the control channel
+- `crash-report.txt`: legacy/interrupted fallback report atomically claimed into the pending spool at startup without being replaced by a newer fatal report
+- `crash-report.pending-*.txt`: private, uniquely written or atomically claimed crash reports; consecutive failures remain separate, successful delivery removes only its owned spool file, and failed delivery retains it for startup recovery
 - `restart.flag`: JSON restart request consumed and removed by `src/runner.js`
 
 Packaged-install artifacts beside the executable:
@@ -54,10 +57,11 @@ On non-Windows platforms, code explicitly enforces:
 
 - `storage/`: `0700`
 - `storage/wa2dc.sqlite`: `0600`
+- crash-report canonical, temporary, and pending spool files: `0600`
 - directories created for local downloads: `0700`
 - downloaded media files: `0600`
 
-Do not generalize those guarantees to `.env`, SQLite WAL/SHM sidecars, logs, crash reports, restart flags, packaged sidecars, or rollback files. Those artifacts follow their creation API and process umask unless separately protected. Treat them as sensitive and recommend restrictive host permissions without claiming WA2DC enforces them.
+Do not generalize those guarantees to `.env`, SQLite WAL/SHM sidecars, logs, restart flags, packaged sidecars, or rollback files. Those artifacts follow their creation API and process umask unless separately protected. Treat them as sensitive and recommend restrictive host permissions without claiming WA2DC enforces them.
 
 WA2DC does not create or chmod `.env`. Operators should restrict it to the runtime account, for example `chmod 600 .env` on Unix-like systems.
 

--- a/docs/dev/testing-and-release.md
+++ b/docs/dev/testing-and-release.md
@@ -15,6 +15,8 @@ Preferred checks before handoff:
 - `WA2DC_SMOKE_TEST=1 node src/index.js` for startup-sensitive changes
 - `npm run build:bin:smoke` when packaging or runtime-sidecar behavior changes
 
+The normal smoke mode skips external transports and exits itself, so it does not exercise signal handling. Process-lifecycle changes also require the focused shutdown tests, which inject stuck ingress, saves, reporters, and spawned/cluster workers to verify ordered persistence, validated supervisor IPC, source-aware duplicate coalescing, deliberate second-signal behavior, actual-child exit tracking, and watchdog `SIGKILL` escalation without using live credentials. Run source and packaged signal smoke with `WA2DC_SMOKE_TEST=1 WA2DC_SMOKE_WAIT_FOR_SIGNAL=1`, wait for the ready message, and send Ctrl-C; both watchdog and worker must exit. Crash-report queue tests verify bounded log-tail reads, private atomic writes, identical-content replacement safety, and failed-delivery recovery from claimed spool files.
+
 The `CI` workflow runs for pull requests and pushes to `main` and `next`. It validates Conventional Commit pull-request titles, runs Biome and documentation checks, and runs tests, the ESM bundle smoke test, and packaged smoke tests on Ubuntu, macOS Intel, and Windows. Superseded runs for the same pull request are cancelled. Release builds use Node.js 24 and must remain at or above the supported 24.15.0 floor.
 
 ## Branch and version policy

--- a/src/crashReportQueue.js
+++ b/src/crashReportQueue.js
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const pendingPrefixFor = (filePath) =>
+	`${path.basename(filePath, path.extname(filePath))}.pending-`;
+const pendingSuffixFor = (filePath) => path.extname(filePath) || ".txt";
+
+const createPendingPath = (filePath) => {
+	const resolvedPath = path.resolve(filePath);
+	return path.join(
+		path.dirname(resolvedPath),
+		`${pendingPrefixFor(resolvedPath)}${Date.now()}-${process.pid}-${Math.random()
+			.toString(16)
+			.slice(2)}${pendingSuffixFor(resolvedPath)}`,
+	);
+};
+
+export async function readTextFileTail(
+	filePath,
+	{ maxBytes = 64 * 1024, fsPromises = fs } = {},
+) {
+	const handle = await fsPromises.open(filePath, "r");
+	try {
+		const stat = await handle.stat();
+		const length = Math.min(Math.max(0, maxBytes), stat.size);
+		const buffer = Buffer.alloc(length);
+		const { bytesRead } = await handle.read(
+			buffer,
+			0,
+			length,
+			stat.size - length,
+		);
+		return buffer.subarray(0, bytesRead).toString("utf8");
+	} finally {
+		await handle.close();
+	}
+}
+
+export async function writeCrashReportAtomic(
+	filePath,
+	content,
+	{ fsPromises = fs, mode = 0o600 } = {},
+) {
+	const resolvedPath = path.resolve(filePath);
+	const tempPath = path.join(
+		path.dirname(resolvedPath),
+		`.${path.basename(resolvedPath)}.${process.pid}.${Date.now()}.${Math.random()
+			.toString(16)
+			.slice(2)}.tmp`,
+	);
+	let handle;
+	try {
+		handle = await fsPromises.open(tempPath, "wx", mode);
+		await handle.writeFile(content, "utf8");
+		await handle.sync();
+		await handle.close();
+		handle = null;
+		await fsPromises.rename(tempPath, resolvedPath);
+		await fsPromises.chmod(resolvedPath, mode);
+	} catch (error) {
+		await handle?.close().catch(() => {});
+		await fsPromises.unlink(tempPath).catch(() => {});
+		throw error;
+	}
+}
+
+export async function writePendingCrashReportAtomic(
+	filePath,
+	content,
+	{ fsPromises = fs, mode = 0o600 } = {},
+) {
+	const pendingPath = createPendingPath(filePath);
+	await writeCrashReportAtomic(pendingPath, content, { fsPromises, mode });
+	return pendingPath;
+}
+
+export async function claimCrashReport(
+	filePath,
+	{ fsPromises = fs, mode = 0o600 } = {},
+) {
+	const pendingPath = createPendingPath(filePath);
+	try {
+		await fsPromises.rename(path.resolve(filePath), pendingPath);
+		await fsPromises.chmod(pendingPath, mode);
+		return pendingPath;
+	} catch (error) {
+		if (error?.code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+export async function listPendingCrashReports(
+	filePath,
+	{ fsPromises = fs } = {},
+) {
+	const resolvedPath = path.resolve(filePath);
+	const prefix = pendingPrefixFor(resolvedPath);
+	const suffix = pendingSuffixFor(resolvedPath);
+	let entries;
+	try {
+		entries = await fsPromises.readdir(path.dirname(resolvedPath), {
+			withFileTypes: true,
+		});
+	} catch (error) {
+		if (error?.code === "ENOENT") return [];
+		throw error;
+	}
+	return entries
+		.filter(
+			(entry) =>
+				entry.isFile() &&
+				entry.name.startsWith(prefix) &&
+				entry.name.endsWith(suffix),
+		)
+		.map((entry) => path.join(path.dirname(resolvedPath), entry.name))
+		.sort();
+}
+
+export async function replayQueuedCrashReport({
+	filePath,
+	send,
+	fsPromises = fs,
+}) {
+	const pendingPaths = await listPendingCrashReports(filePath, { fsPromises });
+	const claimedPath = await claimCrashReport(filePath, { fsPromises });
+	if (claimedPath) pendingPaths.push(claimedPath);
+	if (pendingPaths.length === 0) return { status: "missing", sent: 0 };
+
+	let sent = 0;
+	for (const pendingPath of pendingPaths) {
+		const content = await fsPromises.readFile(pendingPath, "utf8");
+		await send(content);
+		await fsPromises.unlink(pendingPath);
+		sent += 1;
+	}
+	return { status: "sent-and-removed", sent };
+}

--- a/src/discordHandler.js
+++ b/src/discordHandler.js
@@ -6377,6 +6377,7 @@ const discordHandler = {
 		await client.login(state.settings.Token);
 		return client;
 	},
+	getCachedControlChannel: () => controlChannel ?? null,
 	setControlChannel,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,15 @@
 import "./loadRuntimeEnvironment.js";
 
 import nodeCrypto from "node:crypto";
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import pino from "pino";
 import pretty from "pino-pretty";
 import packageInfo from "../package.json" with { type: "json" };
+import {
+	readTextFileTail,
+	replayQueuedCrashReport,
+	writePendingCrashReportAtomic,
+} from "./crashReportQueue.js";
 import discordHandler from "./discordHandler.js";
 import { resolveLogLevel } from "./logLevel.js";
 import { shouldIgnoreProcessError } from "./processErrors.js";
@@ -14,12 +19,20 @@ import {
 	getProcessReportFileName,
 	isShutdownEvent,
 } from "./processExitReporting.js";
+import {
+	createPersistenceShutdownGate,
+	createWorkerShutdownController,
+	getInternalShutdownSignal,
+	quiesceRuntimeIngress,
+} from "./shutdown.js";
 import state from "./state.js";
 import storage from "./storage.js";
 import utils from "./utils.js";
 import whatsappHandler from "./whatsappHandler.js";
 
 const isSmokeTest = process.env.WA2DC_SMOKE_TEST === "1";
+const waitForSmokeSignal =
+	isSmokeTest && process.env.WA2DC_SMOKE_WAIT_FOR_SIGNAL === "1";
 
 if (!globalThis.crypto) {
 	globalThis.crypto = nodeCrypto.webcrypto;
@@ -64,11 +77,124 @@ suppressSecretBearingDependencyConsoleLogs();
 		},
 		pino.multistream(streams),
 	);
-	let autoSaver = setInterval(() => storage.save(), 5 * 60 * 1000);
-	let shuttingDown = false;
+	let autoSaver = null;
+	let updaterTimer = null;
+	const persistenceShutdown = createPersistenceShutdownGate({
+		save: () => storage.save(),
+		close: () => storage.close(),
+	});
+	const stopScheduledWork = () => {
+		state.shutdownRequested = true;
+		if (autoSaver) {
+			clearInterval(autoSaver);
+			autoSaver = null;
+		}
+		if (updaterTimer) {
+			clearInterval(updaterTimer);
+			updaterTimer = null;
+		}
+	};
+	const reportProcessExit = async ({ eventName, reason }) => {
+		let logs = "";
+		try {
+			logs = await readTextFileTail("logs.txt");
+			logs = logs.split("\n").slice(-20).join("\n");
+		} catch (readErr) {
+			void readErr;
+		}
+		const content = buildProcessExitReportContent({
+			eventName,
+			reason,
+			logs,
+		});
+		const isShutdown = isShutdownEvent(eventName);
+		const reportFileName = getProcessReportFileName(eventName);
+		const crashFile = "crash-report.txt";
+		let claimedCrashFile = null;
+		if (!isShutdown) {
+			claimedCrashFile = await writePendingCrashReportAtomic(
+				crashFile,
+				content,
+			);
+		}
+		let sent = false;
+		try {
+			const ctrl = discordHandler.getCachedControlChannel();
+			if (ctrl) {
+				if (content.length > 2000) {
+					await ctrl.send({
+						content: `${content.slice(0, 1997)}...`,
+						files: [
+							{
+								attachment: Buffer.from(content, "utf8"),
+								name: reportFileName,
+							},
+						],
+					});
+				} else {
+					await ctrl.send(content);
+				}
+				sent = true;
+			}
+		} catch (error) {
+			state.logger.error("Failed to send process exit info to Discord");
+			state.logger.error(error);
+		}
+		if (sent && claimedCrashFile) {
+			try {
+				await fs.unlink(claimedCrashFile);
+			} catch (error) {
+				state.logger.error("Failed to remove delivered crash report");
+				state.logger.error(error);
+			}
+		}
+	};
+	const quiesceRuntime = () =>
+		quiesceRuntimeIngress({
+			stopDownloadServer: () => utils.stopDownloadServer(),
+			endWhatsApp: () =>
+				state.waClient?.end?.(new Error("Process shutting down")),
+			closeWhatsAppSocket: () => state.waClient?.ws?.close?.(),
+			onError(stage, error) {
+				state.logger.warn({ error, stage }, "Shutdown cleanup step failed");
+			},
+		});
+	const shutdownController = createWorkerShutdownController({
+		isShutdownEvent,
+		getExitCode: getProcessExitCode,
+		onStart: stopScheduledWork,
+		quiesce: quiesceRuntime,
+		save: () => persistenceShutdown.save(),
+		report: reportProcessExit,
+		destroyDiscord: () => state.dcClient?.destroy?.(),
+		finalSave: () => persistenceShutdown.save(),
+		closePersistence: () => persistenceShutdown.close(),
+		onStageError(stage, error) {
+			state.logger.error(
+				{ error, stage },
+				`Failed during ${stage} shutdown stage`,
+			);
+		},
+		onStageTimeout(stage) {
+			state.logger.warn(`${stage} shutdown stage timed out`);
+		},
+	});
+	const handleProcessShutdown = (eventName, reason, source) => {
+		if (!shutdownController.isShuttingDown()) {
+			if (reason != null) {
+				if (isShutdownEvent(eventName)) {
+					state.logger.info(reason);
+				} else {
+					state.logger.error(reason);
+				}
+			}
+			state.logger.info("Exiting!");
+		}
+		void shutdownController.handle(eventName, reason, { source });
+	};
 	["SIGINT", "SIGTERM", "uncaughtException", "unhandledRejection"].forEach(
 		(eventName) => {
-			process.on(eventName, async (err) => {
+			process.on(eventName, (err) => {
 				if (shouldIgnoreProcessError(eventName, err)) {
 					state.logger.warn(
 						{ err, eventName },
@@ -76,74 +202,15 @@ suppressSecretBearingDependencyConsoleLogs();
 					);
 					return;
 				}
-				if (shuttingDown) {
-					return;
-				}
-				shuttingDown = true;
-				clearInterval(autoSaver);
-				if (err != null) {
-					if (isShutdownEvent(eventName)) {
-						state.logger.info(err);
-					} else {
-						state.logger.error(err);
-					}
-				}
-				state.logger.info("Exiting!");
-				let logs = "";
-				try {
-					logs = await fs.promises.readFile("logs.txt", "utf8");
-					logs = logs.split("\n").slice(-20).join("\n");
-				} catch (readErr) {
-					void readErr;
-				}
-				const content = buildProcessExitReportContent({
-					eventName,
-					reason: err,
-					logs,
-				});
-				const isShutdown = isShutdownEvent(eventName);
-				const reportFileName = getProcessReportFileName(eventName);
-				let sent = false;
-				try {
-					const ctrl = await utils.discord.getControlChannel();
-					if (ctrl) {
-						if (content.length > 2000) {
-							await ctrl.send({
-								content: `${content.slice(0, 1997)}...`,
-								files: [
-									{
-										attachment: Buffer.from(content, "utf8"),
-										name: reportFileName,
-									},
-								],
-							});
-						} else {
-							await ctrl.send(content);
-						}
-						sent = true;
-					}
-				} catch (e) {
-					state.logger.error("Failed to send process exit info to Discord");
-					state.logger.error(e);
-				}
-				if (!sent && !isShutdown) {
-					try {
-						await fs.promises.writeFile("crash-report.txt", content, "utf8");
-					} catch (e) {
-						state.logger.error("Failed to write crash report to disk");
-						state.logger.error(e);
-					}
-				}
-				try {
-					await storage.save();
-				} catch (e) {
-					state.logger.error("Failed to save storage");
-					state.logger.error(e);
-				}
-				process.exit(getProcessExitCode(eventName));
+				handleProcessShutdown(eventName, err, "os");
 			});
 		},
 	);
+	process.on("message", (message) => {
+		const signal = getInternalShutdownSignal(message);
+		if (!signal) return;
+		handleProcessShutdown(signal, signal, "supervisor-ipc");
+	});
 
 	state.logger.info("Starting");
 
@@ -173,13 +240,6 @@ suppressSecretBearingDependencyConsoleLogs();
 
 	utils.ensureDownloadServer();
 
-	clearInterval(autoSaver);
-	autoSaver = setInterval(
-		() => storage.save(),
-		state.settings.autoSaveInterval * 1000,
-	);
-	state.logger.info("Changed auto save interval.");
-
 	state.contacts = await storage.parseContacts();
 	state.logger.info("Loaded contacts.");
 
@@ -190,7 +250,14 @@ suppressSecretBearingDependencyConsoleLogs();
 	state.logger.info("Loaded last timestamp.");
 
 	state.lastMessages = await storage.parseLastMessages();
+	persistenceShutdown.markHydrated();
 	state.logger.info("Loaded last messages.");
+	if (shutdownController.isShuttingDown()) return;
+	autoSaver = setInterval(
+		() => storage.save(),
+		state.settings.autoSaveInterval * 1000,
+	);
+	state.logger.info("Changed auto save interval.");
 
 	if (!isSmokeTest) {
 		state.dcClient = await discordHandler.start();
@@ -204,11 +271,12 @@ suppressSecretBearingDependencyConsoleLogs();
 	}
 
 	if (!isSmokeTest) {
-		try {
-			const crashFile = "crash-report.txt";
-			const queued = await fs.promises.readFile(crashFile, "utf8");
-			const ctrl = await utils.discord.getControlChannel();
-			if (ctrl) {
+		const crashFile = "crash-report.txt";
+		void replayQueuedCrashReport({
+			filePath: crashFile,
+			async send(queued) {
+				const ctrl = discordHandler.getCachedControlChannel();
+				if (!ctrl) throw new Error("Discord control channel is unavailable");
 				if (queued.length > 2000) {
 					await ctrl.send({
 						content: `${queued.slice(0, 1997)}...`,
@@ -219,15 +287,17 @@ suppressSecretBearingDependencyConsoleLogs();
 				} else {
 					await ctrl.send(queued);
 				}
-				await fs.promises.unlink(crashFile);
-				state.logger.info("Queued crash report sent.");
-			}
-		} catch (e) {
-			if (e.code !== "ENOENT") {
+			},
+		})
+			.then((result) => {
+				if (result.status === "sent-and-removed") {
+					state.logger.info("Queued crash report sent.");
+				}
+			})
+			.catch((error) => {
 				state.logger.error("Failed to send queued crash report");
-				state.logger.error(e);
-			}
-		}
+				state.logger.error(error);
+			});
 	} else {
 		state.logger.info("Skipping crash report replay for smoke test.");
 	}
@@ -245,7 +315,7 @@ suppressSecretBearingDependencyConsoleLogs();
 		await utils.discord.syncUpdatePrompt();
 		await utils.discord.syncRollbackPrompt();
 
-		setInterval(
+		updaterTimer = setInterval(
 			async () => {
 				await utils.updater.run(version, { prompt: false });
 				await utils.discord.syncUpdatePrompt();
@@ -259,9 +329,11 @@ suppressSecretBearingDependencyConsoleLogs();
 
 	state.logger.info("Bot is now running. Press CTRL-C to exit.");
 
-	if (isSmokeTest) {
+	if (isSmokeTest && !waitForSmokeSignal) {
 		clearInterval(autoSaver);
 		state.logger.info("Smoke test completed successfully.");
 		process.exit(0);
+	} else if (waitForSmokeSignal) {
+		state.logger.info("Smoke test is waiting for a shutdown signal.");
 	}
 })();

--- a/src/runner.js
+++ b/src/runner.js
@@ -20,6 +20,10 @@ import {
 	revertPackagedArtifactsToBackupSync,
 	UPDATE_VALIDATION_WINDOW_MS,
 } from "./runnerLogic.js";
+import {
+	createSupervisorShutdownController,
+	sendInternalShutdownRequest,
+} from "./shutdown.js";
 
 const RESTART_DELAY = resolveRestartDelayMs(process.env.WA2DC_RESTART_DELAY);
 const SAFE_RUNTIME_RESET_WINDOW =
@@ -188,12 +192,23 @@ async function runSupervisorWithSpawn() {
 	let restartAttempts = 0;
 	let workerStartTime = 0;
 	let currentWorker = null;
-	let shuttingDown = false;
+	const shutdownController = createSupervisorShutdownController({
+		getWorker: () => currentWorker,
+		requestWorkerShutdown: (worker, signal, onError) =>
+			sendInternalShutdownRequest(worker, signal, onError),
+		signalWorker:
+			process.platform === "win32"
+				? null
+				: (worker, signal) => worker.kill(signal),
+		forceKillWorker: (worker) => worker.kill("SIGKILL"),
+		clearValidation: updateValidation.clearValidationState,
+		onError(stage, err) {
+			logger.warn({ err, stage }, `Supervisor ${stage} failed`);
+		},
+	});
 
 	const handleExit = (code, signal) => {
-		if (shuttingDown) {
-			process.exit(code ?? 0);
-		}
+		if (shutdownController.onWorkerExit(code)) return;
 
 		const runtime = Date.now() - workerStartTime;
 		const restartRequest = consumeRestartFlagSync(RESTART_FLAG_PATH, {
@@ -257,12 +272,13 @@ async function runSupervisorWithSpawn() {
 	};
 
 	const start = () => {
+		if (shutdownController.isShuttingDown()) return;
 		workerStartTime = Date.now();
 		updateValidation.onWorkerStarted();
 		currentWorker = spawn(process.execPath, [], {
 			env: { ...process.env, [WORKER_ENV_FLAG]: "1" },
-			// biome-ignore format: keep single-quoted tuple for stdin regression guard
-			stdio: ['inherit', 'pipe', 'pipe'],
+			// biome-ignore format: keep single-quoted tuple for stdin/IPC regression guard
+			stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
 		});
 
 		currentWorker.stdout?.pipe(process.stdout);
@@ -280,11 +296,7 @@ async function runSupervisorWithSpawn() {
 
 	["SIGINT", "SIGTERM"].forEach((sig) => {
 		process.on(sig, () => {
-			shuttingDown = true;
-			updateValidation.clearValidationState();
-			if (currentWorker && !currentWorker.killed) {
-				currentWorker.kill(sig);
-			}
+			shutdownController.onSignal(sig);
 		});
 	});
 
@@ -320,12 +332,23 @@ async function main() {
 	let restartAttempts = 0;
 	let workerStartTime = 0;
 	let currentWorker = null;
-	let shuttingDown = false;
+	const shutdownController = createSupervisorShutdownController({
+		getWorker: () => currentWorker,
+		requestWorkerShutdown: (worker, signal, onError) =>
+			sendInternalShutdownRequest(worker, signal, onError),
+		signalWorker:
+			process.platform === "win32"
+				? null
+				: (worker, signal) => worker.process.kill(signal),
+		forceKillWorker: (worker) => worker.process.kill("SIGKILL"),
+		clearValidation: updateValidation.clearValidationState,
+		onError(stage, err) {
+			logger.warn({ err, stage }, `Supervisor ${stage} failed`);
+		},
+	});
 
 	const handleExit = (code, signal) => {
-		if (shuttingDown) {
-			process.exit(code ?? 0);
-		}
+		if (shutdownController.onWorkerExit(code)) return;
 
 		const runtime = Date.now() - workerStartTime;
 		const restartRequest = consumeRestartFlagSync(RESTART_FLAG_PATH, {
@@ -389,6 +412,7 @@ async function main() {
 	};
 
 	const start = () => {
+		if (shutdownController.isShuttingDown()) return;
 		workerStartTime = Date.now();
 		updateValidation.onWorkerStarted();
 		currentWorker = cluster.fork();
@@ -427,11 +451,7 @@ async function main() {
 
 	["SIGINT", "SIGTERM"].forEach((sig) => {
 		process.on(sig, () => {
-			shuttingDown = true;
-			updateValidation.clearValidationState();
-			if (currentWorker?.process && !currentWorker.process.killed) {
-				currentWorker.process.kill(sig);
-			}
+			shutdownController.onSignal(sig);
 		});
 	});
 

--- a/src/shutdown.js
+++ b/src/shutdown.js
@@ -1,0 +1,352 @@
+export const WORKER_SHUTDOWN_TIMEOUT_MS = 10_000;
+export const INITIAL_SAVE_TIMEOUT_MS = 1_000;
+export const EXIT_REPORT_TIMEOUT_MS = 3_000;
+export const RUNTIME_CLEANUP_TIMEOUT_MS = 2_000;
+export const DISCORD_CLEANUP_TIMEOUT_MS = 1_000;
+export const PERSISTENCE_SHUTDOWN_TIMEOUT_MS = 1_000;
+export const SUPERVISOR_SHUTDOWN_TIMEOUT_MS = 12_000;
+export const SUPERVISOR_FORCE_EXIT_TIMEOUT_MS = 2_000;
+export const DUPLICATE_SIGNAL_WINDOW_MS = 500;
+export const INTERNAL_SHUTDOWN_MESSAGE_TYPE = "wa2dc:shutdown";
+
+const SHUTDOWN_SIGNALS = new Set(["SIGINT", "SIGTERM"]);
+
+export const createInternalShutdownMessage = (signal) => ({
+	type: INTERNAL_SHUTDOWN_MESSAGE_TYPE,
+	signal,
+});
+
+export const getInternalShutdownSignal = (message) =>
+	message &&
+	typeof message === "object" &&
+	!Array.isArray(message) &&
+	message.type === INTERNAL_SHUTDOWN_MESSAGE_TYPE &&
+	SHUTDOWN_SIGNALS.has(message.signal)
+		? message.signal
+		: null;
+
+export function sendInternalShutdownRequest(
+	worker,
+	signal,
+	onError = () => {},
+) {
+	if (!SHUTDOWN_SIGNALS.has(signal) || typeof worker?.send !== "function") {
+		return false;
+	}
+	if (worker.connected === false || worker.isConnected?.() === false) {
+		return false;
+	}
+
+	worker.send(createInternalShutdownMessage(signal), (error) => {
+		if (error) onError(error);
+	});
+	return true;
+}
+
+export function createPersistenceShutdownGate({ save, close }) {
+	let hydrated = false;
+	return {
+		markHydrated() {
+			hydrated = true;
+		},
+		save() {
+			return hydrated ? save() : undefined;
+		},
+		close() {
+			return hydrated ? close() : undefined;
+		},
+		isHydrated: () => hydrated,
+	};
+}
+
+export async function quiesceRuntimeIngress({
+	stopDownloadServer = () => {},
+	endWhatsApp = () => {},
+	closeWhatsAppSocket = () => {},
+	onError = () => {},
+}) {
+	const pending = [];
+	const start = (stage, operation) => {
+		try {
+			pending.push(
+				Promise.resolve(operation()).catch((error) => onError(stage, error)),
+			);
+		} catch (error) {
+			onError(stage, error);
+		}
+	};
+
+	start("download-server", stopDownloadServer);
+	start("whatsapp-end", endWhatsApp);
+	start("whatsapp-socket", closeWhatsAppSocket);
+	await Promise.allSettled(pending);
+}
+
+const settleWithin = (
+	operation,
+	timeoutMs,
+	{ setTimer = setTimeout, clearTimer = clearTimeout } = {},
+) =>
+	new Promise((resolve) => {
+		let settled = false;
+		const finish = (result) => {
+			if (settled) return;
+			settled = true;
+			clearTimer(timer);
+			resolve(result);
+		};
+		const timer = setTimer(
+			() => finish({ status: "timeout" }),
+			Math.max(0, timeoutMs),
+		);
+
+		Promise.resolve()
+			.then(operation)
+			.then(
+				(value) => finish({ status: "fulfilled", value }),
+				(reason) => finish({ status: "rejected", reason }),
+			);
+	});
+
+export function createWorkerShutdownController({
+	isShutdownEvent,
+	getExitCode,
+	onStart = () => {},
+	quiesce = async () => {},
+	save = async () => {},
+	report = async () => {},
+	destroyDiscord = async () => {},
+	finalSave = save,
+	closePersistence = async () => {},
+	onStageError = () => {},
+	onStageTimeout = () => {},
+	exit = (code) => process.exit(code),
+	shutdownTimeoutMs = WORKER_SHUTDOWN_TIMEOUT_MS,
+	initialSaveTimeoutMs = INITIAL_SAVE_TIMEOUT_MS,
+	reportTimeoutMs = EXIT_REPORT_TIMEOUT_MS,
+	cleanupTimeoutMs = RUNTIME_CLEANUP_TIMEOUT_MS,
+	discordTimeoutMs = DISCORD_CLEANUP_TIMEOUT_MS,
+	persistenceTimeoutMs = PERSISTENCE_SHUTDOWN_TIMEOUT_MS,
+	duplicateSignalWindowMs = DUPLICATE_SIGNAL_WINDOW_MS,
+	now = Date.now,
+	setTimer = setTimeout,
+	clearTimer = clearTimeout,
+}) {
+	let shuttingDown = false;
+	let exitRequested = false;
+	let hardExitTimer = null;
+	let firstSignal = null;
+	let firstSignalSource = null;
+	let firstSignalAt = 0;
+	let duplicateSignalCoalesced = false;
+
+	const requestExit = (code) => {
+		if (exitRequested) return;
+		exitRequested = true;
+		if (hardExitTimer) {
+			clearTimer(hardExitTimer);
+			hardExitTimer = null;
+		}
+		exit(code);
+	};
+
+	const runBoundedStage = async (stage, operation, timeoutMs) => {
+		const result = await settleWithin(operation, timeoutMs, {
+			setTimer,
+			clearTimer,
+		});
+		if (result.status === "rejected") {
+			onStageError(stage, result.reason);
+		} else if (result.status === "timeout") {
+			onStageTimeout(stage);
+		}
+	};
+
+	const handle = async (eventName, reason, { source = "os" } = {}) => {
+		const exitCode = getExitCode(eventName);
+		if (shuttingDown) {
+			if (isShutdownEvent(eventName)) {
+				const isForwardedDuplicate =
+					eventName === firstSignal &&
+					source !== firstSignalSource &&
+					!duplicateSignalCoalesced &&
+					now() - firstSignalAt < duplicateSignalWindowMs;
+				if (isForwardedDuplicate) {
+					duplicateSignalCoalesced = true;
+				} else {
+					requestExit(exitCode);
+				}
+			}
+			return;
+		}
+
+		shuttingDown = true;
+		if (isShutdownEvent(eventName)) {
+			firstSignal = eventName;
+			firstSignalSource = source;
+			firstSignalAt = now();
+		}
+		hardExitTimer = setTimer(
+			() => requestExit(exitCode),
+			Math.max(0, shutdownTimeoutMs),
+		);
+
+		try {
+			onStart({ eventName, reason, exitCode });
+			await runBoundedStage("quiesce", quiesce, cleanupTimeoutMs);
+			await runBoundedStage(
+				"save",
+				() => save({ eventName, reason, exitCode }),
+				initialSaveTimeoutMs,
+			);
+			await runBoundedStage(
+				"report",
+				() => report({ eventName, reason, exitCode }),
+				reportTimeoutMs,
+			);
+		} finally {
+			await runBoundedStage(
+				"destroy-discord",
+				destroyDiscord,
+				discordTimeoutMs,
+			);
+			await runBoundedStage("final-save", finalSave, persistenceTimeoutMs);
+			await runBoundedStage(
+				"close-persistence",
+				closePersistence,
+				persistenceTimeoutMs,
+			);
+			requestExit(exitCode);
+		}
+	};
+
+	return {
+		handle,
+		isShuttingDown: () => shuttingDown,
+	};
+}
+
+export function createSupervisorShutdownController({
+	getWorker,
+	requestWorkerShutdown = () => false,
+	signalWorker = null,
+	forceKillWorker,
+	clearValidation = () => {},
+	onError = () => {},
+	exit = (code) => process.exit(code),
+	graceTimeoutMs = SUPERVISOR_SHUTDOWN_TIMEOUT_MS,
+	forceExitTimeoutMs = SUPERVISOR_FORCE_EXIT_TIMEOUT_MS,
+	setTimer = setTimeout,
+	clearTimer = clearTimeout,
+}) {
+	let shuttingDown = false;
+	let exitRequested = false;
+	let graceTimer = null;
+	let forceExitTimer = null;
+	let forceKillRequested = false;
+
+	const requestExit = (code) => {
+		if (exitRequested) return;
+		exitRequested = true;
+		if (graceTimer) {
+			clearTimer(graceTimer);
+			graceTimer = null;
+		}
+		if (forceExitTimer) {
+			clearTimer(forceExitTimer);
+			forceExitTimer = null;
+		}
+		exit(code);
+	};
+
+	const forceKill = () => {
+		const worker = getWorker();
+		if (!worker) return false;
+		try {
+			const killed = forceKillWorker(worker);
+			if (killed === false) {
+				onError("force-kill", new Error("Worker rejected SIGKILL"));
+			}
+		} catch (error) {
+			onError("force-kill", error);
+		}
+		return true;
+	};
+
+	const beginForceKill = () => {
+		if (forceKillRequested) {
+			requestExit(0);
+			return;
+		}
+		forceKillRequested = true;
+		if (graceTimer) {
+			clearTimer(graceTimer);
+			graceTimer = null;
+		}
+		if (!forceKill()) {
+			requestExit(0);
+			return;
+		}
+		forceExitTimer = setTimer(
+			() => {
+				forceExitTimer = null;
+				requestExit(0);
+			},
+			Math.max(0, forceExitTimeoutMs),
+		);
+	};
+
+	const fallbackToSignal = (worker, signal, error) => {
+		if (error) onError("shutdown-ipc", error);
+		if (!signalWorker || exitRequested || forceKillRequested) return;
+		try {
+			signalWorker(worker, signal);
+		} catch (signalError) {
+			onError("signal", signalError);
+		}
+	};
+
+	const onSignal = (signal) => {
+		if (shuttingDown) {
+			beginForceKill();
+			return;
+		}
+
+		shuttingDown = true;
+		clearValidation();
+		const worker = getWorker();
+		if (!worker) {
+			requestExit(0);
+			return;
+		}
+
+		try {
+			const requested = requestWorkerShutdown(worker, signal, (error) =>
+				fallbackToSignal(worker, signal, error),
+			);
+			if (!requested) fallbackToSignal(worker, signal);
+		} catch (error) {
+			fallbackToSignal(worker, signal, error);
+		}
+
+		graceTimer = setTimer(
+			() => {
+				graceTimer = null;
+				beginForceKill();
+			},
+			Math.max(0, graceTimeoutMs),
+		);
+	};
+
+	const onWorkerExit = (code) => {
+		if (!shuttingDown) return false;
+		requestExit(code ?? 0);
+		return true;
+	};
+
+	return {
+		onSignal,
+		onWorkerExit,
+		isShuttingDown: () => shuttingDown,
+	};
+}

--- a/tests/crashReportQueue.test.js
+++ b/tests/crashReportQueue.test.js
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+	listPendingCrashReports,
+	readTextFileTail,
+	replayQueuedCrashReport,
+	writeCrashReportAtomic,
+	writePendingCrashReportAtomic,
+} from "../src/crashReportQueue.js";
+
+test("shutdown log reads are bounded to the tail of the file", async (t) => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wa2dc-log-tail-"));
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const logFile = path.join(tempDir, "logs.txt");
+	await fs.writeFile(logFile, "older-data\nnewest-data", "utf8");
+
+	assert.equal(
+		await readTextFileTail(logFile, { maxBytes: 11 }),
+		"newest-data",
+	);
+});
+
+test("shutdown log tail uses only bytes actually read", async () => {
+	let closed = false;
+	const fsPromises = {
+		async open() {
+			return {
+				async stat() {
+					return { size: 10 };
+				},
+				async read(buffer) {
+					buffer.write("abc", 0, "utf8");
+					return { bytesRead: 3 };
+				},
+				async close() {
+					closed = true;
+				},
+			};
+		},
+	};
+
+	assert.equal(
+		await readTextFileTail("unused", { maxBytes: 10, fsPromises }),
+		"abc",
+	);
+	assert.equal(closed, true);
+});
+
+test("atomic crash reports are replaced with private permissions", async (t) => {
+	const tempDir = await fs.mkdtemp(
+		path.join(os.tmpdir(), "wa2dc-crash-write-"),
+	);
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const crashFile = path.join(tempDir, "crash-report.txt");
+	await writeCrashReportAtomic(crashFile, "old crash");
+	await writeCrashReportAtomic(crashFile, "new crash");
+	assert.equal(await fs.readFile(crashFile, "utf8"), "new crash");
+	if (process.platform !== "win32") {
+		assert.equal((await fs.stat(crashFile)).mode & 0o777, 0o600);
+	}
+});
+
+test("consecutive fatal queue writes preserve earlier and canonical reports", async (t) => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "wa2dc-crash-many-"));
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const crashFile = path.join(tempDir, "crash-report.txt");
+	await writeCrashReportAtomic(crashFile, "legacy crash");
+	await writePendingCrashReportAtomic(crashFile, "first new crash");
+	await writePendingCrashReportAtomic(crashFile, "second new crash");
+
+	assert.equal(await fs.readFile(crashFile, "utf8"), "legacy crash");
+	assert.equal((await listPendingCrashReports(crashFile)).length, 2);
+
+	const delivered = [];
+	assert.deepEqual(
+		await replayQueuedCrashReport({
+			filePath: crashFile,
+			send: async (content) => delivered.push(content),
+		}),
+		{ status: "sent-and-removed", sent: 3 },
+	);
+	assert.deepEqual(
+		new Set(delivered),
+		new Set(["legacy crash", "first new crash", "second new crash"]),
+	);
+	await assert.rejects(fs.stat(crashFile), { code: "ENOENT" });
+	assert.deepEqual(await listPendingCrashReports(crashFile), []);
+});
+
+test("failed new fatal write leaves every existing report untouched", async (t) => {
+	const tempDir = await fs.mkdtemp(
+		path.join(os.tmpdir(), "wa2dc-crash-write-failure-"),
+	);
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const crashFile = path.join(tempDir, "crash-report.txt");
+	await writeCrashReportAtomic(crashFile, "legacy crash");
+	const existingPending = await writePendingCrashReportAtomic(
+		crashFile,
+		"earlier fatal",
+	);
+
+	await assert.rejects(
+		writePendingCrashReportAtomic(crashFile, "new fatal", {
+			fsPromises: {
+				async open() {
+					throw new Error("disk unavailable");
+				},
+				async unlink() {},
+			},
+		}),
+		/disk unavailable/,
+	);
+	assert.equal(await fs.readFile(crashFile, "utf8"), "legacy crash");
+	assert.equal(await fs.readFile(existingPending, "utf8"), "earlier fatal");
+	assert.deepEqual(await listPendingCrashReports(crashFile), [existingPending]);
+});
+
+test("claimed replay cannot delete an identical replacement report", async (t) => {
+	const tempDir = await fs.mkdtemp(
+		path.join(os.tmpdir(), "wa2dc-crash-replay-"),
+	);
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const crashFile = path.join(tempDir, "crash-report.txt");
+	await fs.writeFile(crashFile, "queued crash", "utf8");
+	let releaseSend;
+	let sendStarted;
+	const started = new Promise((resolve) => {
+		sendStarted = resolve;
+	});
+	const sendGate = new Promise((resolve) => {
+		releaseSend = resolve;
+	});
+	const replay = replayQueuedCrashReport({
+		filePath: crashFile,
+		async send(content) {
+			assert.equal(content, "queued crash");
+			sendStarted();
+			await sendGate;
+		},
+	});
+
+	await started;
+	await writeCrashReportAtomic(crashFile, "queued crash");
+	releaseSend();
+
+	assert.deepEqual(await replay, { status: "sent-and-removed", sent: 1 });
+	assert.equal(await fs.readFile(crashFile, "utf8"), "queued crash");
+	assert.deepEqual(await listPendingCrashReports(crashFile), []);
+});
+
+test("failed delivery retains its claimed report for startup recovery", async (t) => {
+	const tempDir = await fs.mkdtemp(
+		path.join(os.tmpdir(), "wa2dc-crash-recovery-"),
+	);
+	t.after(() => fs.rm(tempDir, { recursive: true, force: true }));
+	const crashFile = path.join(tempDir, "crash-report.txt");
+	await writeCrashReportAtomic(crashFile, "recover me");
+
+	await assert.rejects(
+		replayQueuedCrashReport({
+			filePath: crashFile,
+			send: async () => {
+				throw new Error("offline");
+			},
+		}),
+		/offline/,
+	);
+	await assert.rejects(fs.stat(crashFile), { code: "ENOENT" });
+	assert.equal((await listPendingCrashReports(crashFile)).length, 1);
+
+	const delivered = [];
+	assert.deepEqual(
+		await replayQueuedCrashReport({
+			filePath: crashFile,
+			send: async (content) => delivered.push(content),
+		}),
+		{ status: "sent-and-removed", sent: 1 },
+	);
+	assert.deepEqual(delivered, ["recover me"]);
+	assert.deepEqual(await listPendingCrashReports(crashFile), []);
+});

--- a/tests/runnerStdin.test.js
+++ b/tests/runnerStdin.test.js
@@ -13,8 +13,10 @@ test("Watchdog runner keeps stdin available for first-run prompts", async () => 
 	const content = await fs.readFile(runnerPath, "utf8");
 
 	assert.ok(
-		/stdio:\s*\[\s*'inherit'\s*,\s*'pipe'\s*,\s*'pipe'\s*]/.test(content),
-		"Expected worker spawn to inherit stdin (so readline prompts work)",
+		/stdio:\s*\[\s*'inherit'\s*,\s*'pipe'\s*,\s*'pipe'\s*,\s*'ipc'\s*]/.test(
+			content,
+		),
+		"Expected worker spawn to inherit stdin and expose graceful-shutdown IPC",
 	);
 
 	assert.ok(

--- a/tests/shutdown.test.js
+++ b/tests/shutdown.test.js
@@ -1,0 +1,392 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	createPersistenceShutdownGate,
+	createSupervisorShutdownController,
+	createWorkerShutdownController,
+	getInternalShutdownSignal,
+	quiesceRuntimeIngress,
+	sendInternalShutdownRequest,
+} from "../src/shutdown.js";
+
+const isShutdownEvent = (eventName) =>
+	eventName === "SIGINT" || eventName === "SIGTERM";
+const getExitCode = (eventName) => (isShutdownEvent(eventName) ? 0 : 1);
+
+test("runtime quiesce starts every ingress primitive when one fails or hangs", async () => {
+	const calls = [];
+	let releaseWhatsApp;
+	const whatsappEnd = new Promise((resolve) => {
+		releaseWhatsApp = resolve;
+	});
+	const cleanup = quiesceRuntimeIngress({
+		stopDownloadServer() {
+			calls.push("download-server");
+			throw new Error("close failed");
+		},
+		endWhatsApp() {
+			calls.push("whatsapp-end");
+			return whatsappEnd;
+		},
+		closeWhatsAppSocket: () => calls.push("whatsapp-socket"),
+		onError: (stage) => calls.push(`${stage}-error`),
+	});
+
+	assert.deepEqual(calls, [
+		"download-server",
+		"download-server-error",
+		"whatsapp-end",
+		"whatsapp-socket",
+	]);
+	releaseWhatsApp();
+	await cleanup;
+});
+
+test("early shutdown does not save or close partially hydrated persistence", async () => {
+	const calls = [];
+	const persistence = createPersistenceShutdownGate({
+		save: () => calls.push("save"),
+		close: () => calls.push("close"),
+	});
+
+	await persistence.save();
+	await persistence.close();
+	assert.deepEqual(calls, []);
+
+	persistence.markHydrated();
+	await persistence.save();
+	await persistence.close();
+	assert.deepEqual(calls, ["save", "close"]);
+});
+
+test("worker shutdown quiesces, saves, reports, destroys Discord, saves, then closes", async () => {
+	const calls = [];
+	const controller = createWorkerShutdownController({
+		isShutdownEvent,
+		getExitCode,
+		onStart() {
+			calls.push("start");
+		},
+		async quiesce() {
+			calls.push("quiesce");
+		},
+		async save() {
+			calls.push("initial-save");
+		},
+		report() {
+			calls.push("report");
+			return new Promise(() => {});
+		},
+		async destroyDiscord() {
+			calls.push("destroy-discord");
+		},
+		async finalSave() {
+			calls.push("final-save");
+		},
+		async closePersistence() {
+			calls.push("close-persistence");
+		},
+		onStageTimeout(stage) {
+			calls.push(`${stage}-timeout`);
+		},
+		exit(code) {
+			calls.push(`exit-${code}`);
+		},
+		reportTimeoutMs: 5,
+		cleanupTimeoutMs: 50,
+		shutdownTimeoutMs: 500,
+	});
+
+	await controller.handle("SIGINT", "SIGINT");
+
+	assert.deepEqual(calls, [
+		"start",
+		"quiesce",
+		"initial-save",
+		"report",
+		"report-timeout",
+		"destroy-discord",
+		"final-save",
+		"close-persistence",
+		"exit-0",
+	]);
+});
+
+test("hung ingress and initial save cannot block fatal report or final persistence", async () => {
+	const calls = [];
+	const never = new Promise(() => {});
+	const controller = createWorkerShutdownController({
+		isShutdownEvent,
+		getExitCode,
+		quiesce() {
+			calls.push("quiesce");
+			return never;
+		},
+		save() {
+			calls.push("initial-save");
+			return never;
+		},
+		report() {
+			calls.push("report");
+		},
+		destroyDiscord() {
+			calls.push("destroy-discord");
+		},
+		finalSave() {
+			calls.push("final-save");
+		},
+		closePersistence() {
+			calls.push("close-persistence");
+		},
+		onStageTimeout(stage) {
+			calls.push(`${stage}-timeout`);
+		},
+		exit: (code) => calls.push(`exit-${code}`),
+		cleanupTimeoutMs: 5,
+		initialSaveTimeoutMs: 5,
+		reportTimeoutMs: 50,
+		discordTimeoutMs: 50,
+		persistenceTimeoutMs: 50,
+		shutdownTimeoutMs: 500,
+	});
+
+	await controller.handle("uncaughtException", new Error("fatal"));
+	assert.deepEqual(calls, [
+		"quiesce",
+		"quiesce-timeout",
+		"initial-save",
+		"save-timeout",
+		"report",
+		"destroy-discord",
+		"final-save",
+		"close-persistence",
+		"exit-1",
+	]);
+});
+
+test("a second shutdown signal requests immediate exit exactly once", async () => {
+	const exits = [];
+	let releaseReport;
+	const report = new Promise((resolve) => {
+		releaseReport = resolve;
+	});
+	const controller = createWorkerShutdownController({
+		isShutdownEvent,
+		getExitCode,
+		report: () => report,
+		exit: (code) => exits.push(code),
+		reportTimeoutMs: 500,
+		cleanupTimeoutMs: 50,
+		shutdownTimeoutMs: 1_000,
+	});
+
+	const firstSignal = controller.handle("SIGINT", "SIGINT");
+	await new Promise((resolve) => setImmediate(resolve));
+	await controller.handle("SIGTERM", "SIGTERM", { source: "os" });
+
+	assert.deepEqual(exits, [0]);
+	releaseReport();
+	await firstSignal;
+	assert.deepEqual(exits, [0]);
+});
+
+test("only an OS/IPC duplicate is coalesced; a second direct signal exits", async () => {
+	const exits = [];
+	let currentTime = 1_000;
+	let releaseReport;
+	const report = new Promise((resolve) => {
+		releaseReport = resolve;
+	});
+	const controller = createWorkerShutdownController({
+		isShutdownEvent,
+		getExitCode,
+		report: () => report,
+		exit: (code) => exits.push(code),
+		now: () => currentTime,
+		duplicateSignalWindowMs: 500,
+		reportTimeoutMs: 1_000,
+		shutdownTimeoutMs: 2_000,
+	});
+
+	const firstSignal = controller.handle("SIGINT", "SIGINT", { source: "os" });
+	await new Promise((resolve) => setImmediate(resolve));
+	currentTime += 10;
+	await controller.handle("SIGINT", "SIGINT", { source: "supervisor-ipc" });
+	assert.deepEqual(exits, []);
+
+	currentTime += 10;
+	await controller.handle("SIGINT", "SIGINT", { source: "os" });
+	assert.deepEqual(exits, [0]);
+	releaseReport();
+	await firstSignal;
+});
+
+test("validated internal shutdown messages support only graceful signals", () => {
+	assert.equal(
+		getInternalShutdownSignal({ type: "wa2dc:shutdown", signal: "SIGINT" }),
+		"SIGINT",
+	);
+	assert.equal(
+		getInternalShutdownSignal({ type: "wa2dc:shutdown", signal: "SIGKILL" }),
+		null,
+	);
+	assert.equal(getInternalShutdownSignal("SIGTERM"), null);
+});
+
+test("packaged spawn supervisor requests graceful shutdown over IPC", () => {
+	const messages = [];
+	const signals = [];
+	const exits = [];
+	const timers = [];
+	const worker = {
+		connected: true,
+		send(message, callback) {
+			messages.push(message);
+			callback(null);
+		},
+		kill(signal) {
+			signals.push(signal);
+			return true;
+		},
+	};
+	const controller = createSupervisorShutdownController({
+		getWorker: () => worker,
+		requestWorkerShutdown: (target, signal, onError) =>
+			sendInternalShutdownRequest(target, signal, onError),
+		signalWorker: (target, signal) => target.kill(signal),
+		forceKillWorker: (target) => target.kill("SIGKILL"),
+		exit: (code) => exits.push(code),
+		setTimer(callback) {
+			timers.push(callback);
+			return timers.length;
+		},
+		clearTimer() {},
+	});
+
+	controller.onSignal("SIGTERM");
+	assert.deepEqual(messages, [{ type: "wa2dc:shutdown", signal: "SIGTERM" }]);
+	assert.deepEqual(signals, []);
+	assert.deepEqual(exits, []);
+
+	timers[0]();
+	assert.deepEqual(signals, ["SIGKILL"]);
+	assert.deepEqual(exits, []);
+	controller.onWorkerExit(null);
+	assert.deepEqual(exits, [0]);
+});
+
+test("source cluster supervisor sends IPC and observes exit after forced kill", () => {
+	const messages = [];
+	const signals = [];
+	const exits = [];
+	const worker = {
+		isConnected: () => true,
+		send(message, callback) {
+			messages.push(message);
+			callback(null);
+		},
+		process: {
+			kill(signal) {
+				signals.push(signal);
+				return true;
+			},
+		},
+	};
+	const controller = createSupervisorShutdownController({
+		getWorker: () => worker,
+		requestWorkerShutdown: (target, signal, onError) =>
+			sendInternalShutdownRequest(target, signal, onError),
+		signalWorker: (target, signal) => target.process.kill(signal),
+		forceKillWorker: (target) => target.process.kill("SIGKILL"),
+		exit: (code) => exits.push(code),
+		setTimer: () => 1,
+		clearTimer() {},
+	});
+
+	controller.onSignal("SIGINT");
+	controller.onSignal("SIGTERM");
+
+	assert.deepEqual(messages, [{ type: "wa2dc:shutdown", signal: "SIGINT" }]);
+	assert.deepEqual(signals, ["SIGKILL"]);
+	assert.deepEqual(exits, []);
+	controller.onWorkerExit(null);
+	assert.deepEqual(exits, [0]);
+});
+
+test("Windows-style supervisor never falls back to a graceful OS signal", () => {
+	const signals = [];
+	const timers = [];
+	const worker = {
+		kill(signal) {
+			signals.push(signal);
+			return true;
+		},
+	};
+	const controller = createSupervisorShutdownController({
+		getWorker: () => worker,
+		requestWorkerShutdown: () => false,
+		signalWorker: null,
+		forceKillWorker: (target) => target.kill("SIGKILL"),
+		exit() {},
+		setTimer(callback) {
+			timers.push(callback);
+			return timers.length;
+		},
+		clearTimer() {},
+	});
+
+	controller.onSignal("SIGTERM");
+	assert.deepEqual(signals, []);
+	timers[0]();
+	assert.deepEqual(signals, ["SIGKILL"]);
+});
+
+test("supervisor exits from the real worker exit event without escalation", () => {
+	const exits = [];
+	const clearedTimers = [];
+	let worker = { kill() {} };
+	const controller = createSupervisorShutdownController({
+		getWorker: () => worker,
+		requestWorkerShutdown: () => true,
+		signalWorker: (target, signal) => target.kill(signal),
+		forceKillWorker() {
+			assert.fail("worker should not be force-killed after it exits");
+		},
+		exit: (code) => exits.push(code),
+		setTimer: () => 7,
+		clearTimer: (timer) => clearedTimers.push(timer),
+	});
+
+	controller.onSignal("SIGTERM");
+	worker = null;
+	assert.equal(controller.onWorkerExit(null), true);
+
+	assert.deepEqual(clearedTimers, [7]);
+	assert.deepEqual(exits, [0]);
+});
+
+test("failed SIGKILL waits for the post-kill deadline before supervisor exit", () => {
+	const errors = [];
+	const exits = [];
+	const timers = [];
+	const controller = createSupervisorShutdownController({
+		getWorker: () => ({ kill: () => false }),
+		requestWorkerShutdown: () => true,
+		forceKillWorker: (worker) => worker.kill("SIGKILL"),
+		onError: (stage) => errors.push(stage),
+		exit: (code) => exits.push(code),
+		setTimer(callback) {
+			timers.push(callback);
+			return timers.length;
+		},
+		clearTimer() {},
+	});
+
+	controller.onSignal("SIGTERM");
+	timers[0]();
+	assert.deepEqual(errors, ["force-kill"]);
+	assert.deepEqual(exits, []);
+	timers[1]();
+	assert.deepEqual(exits, [0]);
+});


### PR DESCRIPTION
## Summary

- make worker shutdown transactional and bounded across WhatsApp, Discord, and SQLite
- use validated watchdog IPC so Windows and native supervisors exit gracefully before SIGKILL escalation
- preserve crash reports in private unique spool files and replay them without delaying WhatsApp startup
- add cross-platform lifecycle regression tests and developer documentation

## Verification

- npm run check
- npm test (314 tests: 313 passed, 1 skipped)
- npm run docs:check
- npm run bundle
- startup smoke
- packaged binary smoke
- source and packaged foreground Ctrl-C smoke
- source and packaged parent-only IPC shutdown smoke
