### PR TITLE
ci: use GitHub App client ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Create or update release PR
         id: release
@@ -296,7 +296,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Open main-to-next synchronization PR
         env:

--- a/docs/dev/testing-and-release.md
+++ b/docs/dev/testing-and-release.md
@@ -52,7 +52,7 @@ All third-party actions are pinned to full commit SHAs. Dependabot maintains the
 
 Before enabling the workflow in GitHub:
 
-1. Create a repository-scoped GitHub App with Contents, Pull requests, and Issues read/write access, install it only on this repository, set its ID as the `RELEASE_APP_ID` repository variable, and store its private key as the `RELEASE_APP_PRIVATE_KEY` repository secret.
+1. Create a repository-scoped GitHub App with Contents, Pull requests, and Issues read/write access, install it only on this repository, set its Client ID as the `RELEASE_APP_CLIENT_ID` repository variable, and store its private key as the `RELEASE_APP_PRIVATE_KEY` repository secret.
 2. Create the protected `release-signing` environment and store the existing RSA private key as its `SIGN_KEY` secret. Restrict environment deployment to `main` and `next`; require maintainer approval if the repository's threat model needs it.
 3. Merge the automation to `main`, create `next` from that exact commit, and protect both branches. Require `CI` checks, one or more reviews, resolved conversations, and block ordinary direct pushes. Allow the installed release App only where automation needs it.
 4. Enable squash merge for normal work into `next` and merge commits for the `next` to `main` promotion PR. Configure merge-commit titles from the pull-request title and merge-commit messages from the pull-request body so the validated stable `Release-As` footer reaches Release Please. Disable automatic head-branch deletion: `next` is the long-lived promotion head, and deleting it can retarget its open pull requests to `main` before the post-release job runs.

--- a/tests/releaseAutomation.test.js
+++ b/tests/releaseAutomation.test.js
@@ -188,6 +188,15 @@ test("workflow configuration covers CI, draft recovery, native targets, and immu
 	assert.match(ci, /sleep 10/u);
 	assert.match(release, /workflow_dispatch:/u);
 	assert.match(release, /ubuntu-24\.04-arm/u);
+	assert.equal(
+		[
+			...release.matchAll(
+				/^\s+client-id: \$\{\{ vars\.RELEASE_APP_CLIENT_ID \}\}$/gmu,
+			),
+		].length,
+		2,
+	);
+	assert.doesNotMatch(release, /^\s+app-id:/mu);
 	assert.match(
 		release,
 		/resolve:\r?\n[\s\S]*?permissions:\r?\n\s+# Draft releases[^\r\n]*\r?\n\s+contents: write/u,


### PR DESCRIPTION
## Summary

- replace the deprecated GitHub App `app-id` input with `client-id` in release and synchronization jobs
- document the `RELEASE_APP_CLIENT_ID` repository variable
- add workflow regression coverage that rejects future `app-id` usage

## Verification

- npm run ci:check
- npm run docs:check (3 tests passed)
- node --test tests/releaseAutomation.test.js (6 tests passed)
- git diff --check
