### PR TITLE
fix: prevent recent message mapping loss

### DIFF
--- a/docs/dev/bridge-constraints.md
+++ b/docs/dev/bridge-constraints.md
@@ -11,7 +11,7 @@ Mirrored events must not bounce indefinitely between transports. Preserve and ex
 - `state.sentMessages`
 - `state.sentReactions`
 - `state.sentPins`
-- bidirectional recent-message mappings in `state.lastMessages`
+- bounded bidirectional recent-message mappings in `state.lastMessages`; repeated writes refresh existing keys without consuming additional capacity, and album mappings may retain several WhatsApp IDs pointing to one Discord message
 - TTL message payloads in `src/messageStore.js`
 
 Newsletter pending-send/server-ID correlation has separate bounded state in `src/newsletterBridge.js`; do not substitute ordinary Baileys outbound IDs where WhatsApp requires a newsletter `server_id`.

--- a/docs/dev/storage-and-side-effects.md
+++ b/docs/dev/storage-and-side-effects.md
@@ -18,6 +18,8 @@ Table responsibilities:
 
 `src/contracts.js` owns settings defaults and normalization. `src/chatLinks.js` accepts object records with webhook `channelId` and optional `threadId`; unsupported legacy channel-string records are ignored. `src/messageStore.js` bounds cached entries and prunes expired/old records.
 
+Recent WhatsApp↔Discord message mappings remain JSON-compatible but are managed by a unique-key bounded map. Refreshing an existing pair must not consume additional capacity or evict unrelated mappings. Saves are serialized, include privacy-safe cardinality diagnostics, and recover from the previous in-memory snapshot instead of persisting an unexplained drop of more than half of a non-trivial mapping set.
+
 SQLite may create `wa2dc.sqlite-wal` and `wa2dc.sqlite-shm` while running. Stop WA2DC before filesystem-level backup so the copied database is consistent; copy the complete `storage/` directory rather than selecting individual files.
 
 On `SIGINT` or `SIGTERM`, WA2DC blocks reconnect work, independently quiesces download and WhatsApp ingress, and saves current app state before attempting its bounded Discord shutdown report. It then destroys Discord, saves once more, and closes SQLite last. Every stage has a deadline, so a stuck transport cannot prevent the final save/close attempt; operators should continue to stop WA2DC normally before copying storage.

--- a/src/internal/recentMessageMap.js
+++ b/src/internal/recentMessageMap.js
@@ -1,0 +1,107 @@
+const DEFAULT_CAPACITY = 1000;
+
+const metadataByMap = new WeakMap();
+
+const normalizeCapacity = (value) => {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) return DEFAULT_CAPACITY;
+	return Math.max(2, Math.floor(parsed));
+};
+
+const toPropertyKey = (value) =>
+	typeof value === "symbol" ? value : String(value);
+
+const touch = (order, key) => {
+	order.delete(key);
+	order.set(key, true);
+};
+
+export const createRecentMessageMap = (capacity, data = {}) => {
+	const limit = normalizeCapacity(capacity);
+	const backing = Object.create(null);
+	if (data && typeof data === "object" && !Array.isArray(data)) {
+		for (const [key, value] of Object.entries(data)) {
+			Reflect.set(backing, key, value);
+		}
+	}
+
+	const order = new Map(Object.keys(backing).map((key) => [key, true]));
+	const metadata = {
+		capacity: limit,
+		deleteOperations: 0,
+		evictedEntries: 0,
+		initiallyPrunedEntries: 0,
+		setOperations: 0,
+	};
+
+	const evictOverflow = (initializing = false) => {
+		while (order.size > limit) {
+			const oldest = order.keys().next().value;
+			order.delete(oldest);
+			if (Reflect.deleteProperty(backing, oldest)) {
+				if (initializing) metadata.initiallyPrunedEntries += 1;
+				else metadata.evictedEntries += 1;
+			}
+		}
+	};
+
+	evictOverflow(true);
+
+	const proxy = new Proxy(backing, {
+		deleteProperty(target, property) {
+			const key = toPropertyKey(property);
+			const existed = Object.hasOwn(target, key);
+			const deleted = Reflect.deleteProperty(target, key);
+			if (deleted) {
+				order.delete(key);
+				if (existed) metadata.deleteOperations += 1;
+			}
+			return deleted;
+		},
+		set(target, property, value) {
+			if (typeof property === "symbol") {
+				return Reflect.set(target, property, value);
+			}
+
+			const key = toPropertyKey(property);
+			const reverseKey = toPropertyKey(value);
+			Reflect.set(target, key, value);
+			touch(order, key);
+
+			Reflect.set(target, reverseKey, key);
+			touch(order, reverseKey);
+			metadata.setOperations += 1;
+			evictOverflow();
+			return true;
+		},
+	});
+
+	metadataByMap.set(proxy, { metadata, order });
+	return proxy;
+};
+
+export const getRecentMessageMapStats = (value) => {
+	const managed = metadataByMap.get(value);
+	if (!managed) {
+		return {
+			managed: false,
+			capacity: null,
+			entryCount:
+				value && typeof value === "object" ? Object.keys(value).length : 0,
+			deleteOperations: 0,
+			evictedEntries: 0,
+			initiallyPrunedEntries: 0,
+			setOperations: 0,
+		};
+	}
+
+	return {
+		managed: true,
+		capacity: managed.metadata.capacity,
+		entryCount: managed.order.size,
+		deleteOperations: managed.metadata.deleteOperations,
+		evictedEntries: managed.metadata.evictedEntries,
+		initiallyPrunedEntries: managed.metadata.initiallyPrunedEntries,
+		setOperations: managed.metadata.setOperations,
+	};
+};

--- a/src/storage.js
+++ b/src/storage.js
@@ -5,11 +5,17 @@ import discordJs from "discord.js";
 import { normalizeChatLinks } from "./chatLinks.js";
 import { createDiscordClient } from "./clientFactories.js";
 import { normalizeSettings } from "./contracts.js";
+import {
+	createRecentMessageMap,
+	getRecentMessageMapStats,
+} from "./internal/recentMessageMap.js";
 import sqliteStore from "./persistence/sqliteStore.js";
 import state from "./state.js";
 
 const isSmokeTest = process.env.WA2DC_SMOKE_TEST === "1";
 const STORAGE_DIR_MODE = 0o700;
+const CATASTROPHIC_MAPPING_DROP_MIN_ENTRIES = 100;
+const CATASTROPHIC_MAPPING_DROP_RATIO = 0.5;
 
 const { ChannelType, GatewayIntentBits } = discordJs;
 
@@ -25,27 +31,11 @@ const sanitizeStorageKey = (name = "") => {
 	return base;
 };
 
-const bidirectionalMap = (capacity, data) => {
-	const backing =
-		data && typeof data === "object" && !Array.isArray(data) ? data : {};
-	const keys = Object.keys(backing);
-	return new Proxy(backing, {
-		set(target, prop, newVal) {
-			keys.push(prop, newVal);
-			if (keys.length > capacity) {
-				delete target[keys.shift()];
-				delete target[keys.shift()];
-			}
-			target[prop] = newVal;
-			target[newVal] = prop;
-			return true;
-		},
-	});
-};
-
 const storage = {
 	_storageDir: "./storage/",
 	_initialized: false,
+	_lastMessagesSnapshot: null,
+	_saveQueue: Promise.resolve(),
 	_settingsName: "settings",
 	_chatsName: "chats",
 	_contactsName: "contacts",
@@ -78,8 +68,11 @@ const storage = {
 	},
 
 	async close() {
+		await this._saveQueue.catch(() => {});
 		sqliteStore.close();
 		this._initialized = false;
+		this._lastMessagesSnapshot = null;
+		this._saveQueue = Promise.resolve();
 	},
 
 	async upsert(name, data) {
@@ -148,18 +141,45 @@ const storage = {
 		const result = sqliteStore.getAppState(this._lastMessagesName);
 		const capacity = state.settings.lastMessageStorage * 2;
 		if (!result) {
-			return bidirectionalMap(capacity);
+			const map = createRecentMessageMap(capacity);
+			this._lastMessagesSnapshot = {
+				entryCount: 0,
+				serialized: "{}",
+			};
+			return map;
 		}
 
 		try {
 			const parsed = JSON.parse(result);
-			return bidirectionalMap(capacity, parsed);
+			const map = createRecentMessageMap(capacity, parsed);
+			const serialized = JSON.stringify(map);
+			const stats = getRecentMessageMapStats(map);
+			this._lastMessagesSnapshot = {
+				entryCount: stats.entryCount,
+				serialized,
+			};
+			if (stats.initiallyPrunedEntries > 0) {
+				state.logger?.info?.(
+					{
+						capacity: stats.capacity,
+						entryCount: stats.entryCount,
+						prunedEntryCount: stats.initiallyPrunedEntries,
+					},
+					"Pruned recent-message mappings to the configured capacity.",
+				);
+			}
+			return map;
 		} catch (err) {
 			state.logger?.warn?.(
 				{ err },
 				"Failed to parse lastMessages; resetting to empty.",
 			);
-			return bidirectionalMap(capacity);
+			const map = createRecentMessageMap(capacity);
+			this._lastMessagesSnapshot = {
+				entryCount: 0,
+				serialized: "{}",
+			};
+			return map;
 		}
 	},
 
@@ -169,8 +189,42 @@ const storage = {
 		return result ? parseInt(result, 10) : Math.round(Date.now() / 1000);
 	},
 
-	async save() {
+	async _saveNow() {
 		await this.ensureInitialized();
+		let lastMessages = state.lastMessages ?? {};
+		let serializedLastMessages = JSON.stringify(lastMessages);
+		let mappingStats = getRecentMessageMapStats(lastMessages);
+		const previousSnapshot = this._lastMessagesSnapshot;
+		const catastrophicDrop =
+			previousSnapshot?.entryCount >= CATASTROPHIC_MAPPING_DROP_MIN_ENTRIES &&
+			mappingStats.entryCount <
+				previousSnapshot.entryCount * CATASTROPHIC_MAPPING_DROP_RATIO;
+
+		if (catastrophicDrop) {
+			const previousMappings = JSON.parse(previousSnapshot.serialized);
+			const currentMappings = JSON.parse(serializedLastMessages);
+			const mergedMappings = Object.assign(
+				Object.create(null),
+				previousMappings,
+				currentMappings,
+			);
+			lastMessages = createRecentMessageMap(
+				state.settings.lastMessageStorage * 2,
+				mergedMappings,
+			);
+			state.lastMessages = lastMessages;
+			serializedLastMessages = JSON.stringify(lastMessages);
+			mappingStats = getRecentMessageMapStats(lastMessages);
+			state.logger?.error?.(
+				{
+					observedEntryCount: Object.keys(currentMappings).length,
+					previousEntryCount: previousSnapshot.entryCount,
+					recoveredEntryCount: mappingStats.entryCount,
+				},
+				"Recovered recent-message mappings after an unexpected cardinality drop.",
+			);
+		}
+
 		sqliteStore.transaction(() => {
 			sqliteStore.setAppState(
 				this._settingsName,
@@ -181,12 +235,35 @@ const storage = {
 				this._contactsName,
 				JSON.stringify(state.contacts),
 			);
-			sqliteStore.setAppState(
-				this._lastMessagesName,
-				JSON.stringify(state.lastMessages ?? {}),
-			);
+			sqliteStore.setAppState(this._lastMessagesName, serializedLastMessages);
 			sqliteStore.setAppState(this._startTimeName, state.startTime.toString());
 		});
+
+		this._lastMessagesSnapshot = {
+			entryCount: mappingStats.entryCount,
+			serialized: serializedLastMessages,
+		};
+		state.logger?.debug?.(
+			{
+				capacity: mappingStats.capacity,
+				deleteOperations: mappingStats.deleteOperations,
+				entryCount: mappingStats.entryCount,
+				evictedEntryCount: mappingStats.evictedEntries,
+				managed: mappingStats.managed,
+				previousEntryCount: previousSnapshot?.entryCount ?? null,
+				setOperations: mappingStats.setOperations,
+			},
+			"Persisted recent-message mappings.",
+		);
+	},
+
+	save() {
+		const operation = this._saveQueue.then(
+			() => this._saveNow(),
+			() => this._saveNow(),
+		);
+		this._saveQueue = operation.catch(() => {});
+		return operation;
 	},
 
 	async getAuthCredsRaw() {

--- a/tests/recentMessageMap.test.js
+++ b/tests/recentMessageMap.test.js
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	createRecentMessageMap,
+	getRecentMessageMapStats,
+} from "../src/internal/recentMessageMap.js";
+
+test("refreshing an existing mapping does not evict unrelated mappings", () => {
+	const map = createRecentMessageMap(6, {
+		a: "b",
+		b: "a",
+		c: "d",
+		d: "c",
+		e: "f",
+		f: "e",
+	});
+
+	for (let index = 0; index < 20; index += 1) {
+		map.a = "b";
+		map.b = "a";
+	}
+
+	assert.deepEqual(Object.keys(map).sort(), ["a", "b", "c", "d", "e", "f"]);
+	assert.equal(map.c, "d");
+	assert.equal(map.f, "e");
+	assert.deepEqual(getRecentMessageMapStats(map), {
+		managed: true,
+		capacity: 6,
+		entryCount: 6,
+		deleteOperations: 0,
+		evictedEntries: 0,
+		initiallyPrunedEntries: 0,
+		setOperations: 40,
+	});
+});
+
+test("capacity eviction is based on unique keys", () => {
+	const map = createRecentMessageMap(4, {
+		a: "b",
+		b: "a",
+		c: "d",
+		d: "c",
+	});
+
+	map.e = "f";
+
+	assert.deepEqual(Object.keys(map).sort(), ["c", "d", "e", "f"]);
+	assert.equal(map.e, "f");
+	assert.equal(map.f, "e");
+	assert.equal(getRecentMessageMapStats(map).evictedEntries, 2);
+});
+
+test("album mappings keep every WhatsApp ID and one primary reverse mapping", () => {
+	const map = createRecentMessageMap(100);
+
+	for (let index = 1; index <= 10; index += 1) {
+		map[`wa-image-${index}`] = "dc-album";
+	}
+	map["dc-album"] = "wa-image-1";
+
+	for (let index = 1; index <= 10; index += 1) {
+		assert.equal(map[`wa-image-${index}`], "dc-album");
+	}
+	assert.equal(map["dc-album"], "wa-image-1");
+	assert.equal(getRecentMessageMapStats(map).entryCount, 11);
+});

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -230,3 +230,102 @@ test("storage.save never persists lastMessages as null", async () => {
 	restoreObject(state.settings, settingsSnapshot);
 	state.lastMessages = originalLastMessages;
 });
+
+test("storage.save recovers an unexplained catastrophic mapping drop", async () => {
+	const settingsSnapshot = snapshotObject(state.settings);
+	const originalLastMessages = state.lastMessages;
+	const originalLogger = state.logger;
+	const errors = [];
+
+	try {
+		await withTempStorage(async () => {
+			state.settings.lastMessageStorage = 500;
+			state.logger = {
+				debug() {},
+				error(fields, message) {
+					errors.push({ fields, message });
+				},
+				info() {},
+				warn() {},
+			};
+			const seed = {};
+			for (let index = 0; index < 100; index += 1) {
+				seed[`wa-${index}`] = `dc-${index}`;
+				seed[`dc-${index}`] = `wa-${index}`;
+			}
+			await storage.upsert("lastMessages", JSON.stringify(seed));
+			state.lastMessages = await storage.parseLastMessages();
+
+			state.lastMessages = {};
+			await storage.save();
+
+			const persisted = JSON.parse(
+				(await storage.get("lastMessages")).toString("utf8"),
+			);
+			assert.equal(Object.keys(persisted).length, 200);
+			assert.equal(state.lastMessages["wa-99"], "dc-99");
+			assert.equal(errors.length, 1);
+			assert.deepEqual(errors[0], {
+				fields: {
+					observedEntryCount: 0,
+					previousEntryCount: 200,
+					recoveredEntryCount: 200,
+				},
+				message:
+					"Recovered recent-message mappings after an unexpected cardinality drop.",
+			});
+		});
+	} finally {
+		restoreObject(state.settings, settingsSnapshot);
+		state.lastMessages = originalLastMessages;
+		state.logger = originalLogger;
+	}
+});
+
+test("production-sized mappings survive repeated refreshes and a ten-image canary", async () => {
+	const settingsSnapshot = snapshotObject(state.settings);
+	const originalLastMessages = state.lastMessages;
+
+	try {
+		await withTempStorage(async () => {
+			state.settings.lastMessageStorage = 50_000;
+			const seed = {};
+			for (let index = 0; index < 48_343; index += 1) {
+				seed[`wa-seed-${index}`] = `dc-seed-${index}`;
+				seed[`dc-seed-${index}`] = `wa-seed-${index}`;
+			}
+			seed["orphan-reaction"] = true;
+			assert.equal(Object.keys(seed).length, 96_687);
+
+			await storage.upsert("lastMessages", JSON.stringify(seed));
+			state.lastMessages = await storage.parseLastMessages();
+			for (let index = 0; index < 2000; index += 1) {
+				state.lastMessages["wa-hot"] = "dc-hot";
+				state.lastMessages["dc-hot"] = "wa-hot";
+			}
+
+			state.lastMessages["wa-before"] = "dc-before";
+			for (let index = 1; index <= 10; index += 1) {
+				state.lastMessages[`wa-image-${index}`] = "dc-album";
+			}
+			state.lastMessages["dc-album"] = "wa-image-1";
+			state.lastMessages["wa-after"] = "dc-after";
+			await storage.save();
+
+			const persisted = JSON.parse(
+				(await storage.get("lastMessages")).toString("utf8"),
+			);
+			assert.ok(Object.keys(persisted).length >= 96_702);
+			assert.equal(persisted["wa-seed-0"], "dc-seed-0");
+			assert.equal(persisted["wa-before"], "dc-before");
+			assert.equal(persisted["wa-after"], "dc-after");
+			assert.equal(persisted["dc-album"], "wa-image-1");
+			for (let index = 1; index <= 10; index += 1) {
+				assert.equal(persisted[`wa-image-${index}`], "dc-album");
+			}
+		});
+	} finally {
+		restoreObject(state.settings, settingsSnapshot);
+		state.lastMessages = originalLastMessages;
+	}
+});


### PR DESCRIPTION
## Summary

- replace the duplicate-counting recent-message FIFO with unique-key bounded LRU bookkeeping
- preserve WhatsApp album many-to-one mappings while repeated pair refreshes no longer evict unrelated entries
- serialize app-state saves and recover the previous in-memory snapshot on an unexplained mapping-cardinality collapse
- add privacy-safe mapping cardinality and mutation diagnostics

## Production evidence

The v2.5.5 visible canary delivered text, one 10-image album, and following text successfully. During the persistence observation window, the running worker then replaced 96,687 saved mapping entries with an empty object without a restart or parse failure. Production was immediately rolled back to v2.4.0 and the failed v2.5.5 executable/runtime plus a private SQLite diagnostic snapshot were retained.

The previous mapping proxy appended both keys on every assignment, including refreshes of existing pairs. Near capacity, stale duplicate queue entries evicted unrelated live mappings; repeated refreshes could drain the backing object completely.

## Validation

- npm run check
- npm run docs:check
- npm test (599 tests; 597 pass, 2 expected skips)
- npm run bundle plus ESM smoke
- npm run build:bin:smoke
- focused 96,687-entry persistence test with repeated refreshes and text -> 10-image album -> text canary
- simulated full in-memory mapping collapse recovery